### PR TITLE
Add test cases for Go-style map key access

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -195,6 +195,10 @@ func TestEvalIssetAndTernaryExpression(t *testing.T) {
 func TestEvalIndexExpression(t *testing.T) {
 	evalTestCase(t, nil, []string{"111", "222"}, "IndexExpressionSlice_1", `{{.[1]}}`, `222`)
 	evalTestCase(t, nil, map[string]string{"name": "value"}, "IndexExpressionMap_1", `{{.["name"]}}`, "value")
+	evalTestCase(t, nil, map[string]string{"name": "value"}, "IndexExpressionMap_2", `{{.["non_existant_key"]}}`, "")
+	evalTestCase(t, nil, map[string]string{"name": "value"}, "IndexExpressionMap_3", `{{isset(.["non_existant_key"]) ? "key does not exist" : "key does exist"}}`, "key does not exist")
+	evalTestCase(t, nil, map[string]string{"name": "value"}, "IndexExpressionMap_4", `{{if v, ok := .["name"]; ok}}key does exist and has the value '{{v}}'{{else}}key does not exist{{end}}`, "key does exist and has the value 'value'")
+	evalTestCase(t, nil, map[string]string{"name": "value"}, "IndexExpressionMap_5", `{{if v, ok := .["non_existant_key"]; ok}}key does exist and has the value '{{v}}'{{else}}key does not exist{{end}}`, "key does not exist")
 	evalTestCase(t, nil, &User{"José Santos", "email@example.com"}, "IndexExpressionStruct_1", `{{.[0]}}`, "José Santos")
 	evalTestCase(t, nil, &User{"José Santos", "email@example.com"}, "IndexExpressionStruct_2", `{{.["Email"]}}`, "email@example.com")
 }


### PR DESCRIPTION
I added a few test cases that crash or don't compile yet but I think would be useful to make the template language more feature-complete. These revolve around having `isset` work with non-existing keys and using the two-return variant of accessing a map key. Especially for the latter case I often needed to write custom functions on my structs to check for map keys being defined.

These are just nice-to-haves wrapped in failing test cases and if you don't like the syntax you may also close this pull request – in that case we should consider documenting or discussing on how to handle these cases instead so others don't run into the same trouble I did. :)