### PR TITLE
Add ability to use an http.FileSystem for looking up templates

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net/http"
 	"reflect"
 	"runtime"
 	"strings"
@@ -353,6 +354,16 @@ func TestFileResolve(t *testing.T) {
 	//for key, _ := range set.templates {
 	//	t.Log(key)
 	//}
+}
+
+func TestFileSystemResolve(t *testing.T) {
+	set := NewHTMLSet()
+	fs := http.Dir("testData/includeIfNotExists")
+	set.SetFileSystem(fs)
+	RunJetTestWithSet(t, set, nil, nil, "existent", "", "Hi, i exist!!")
+	RunJetTestWithSet(t, set, nil, nil, "notExistent", "", "")
+	RunJetTestWithSet(t, set, nil, nil, "ifIncludeIfExits", "", "Hi, i exist!!\n    Was included!!\n\n\n    Was not included!!\n\n")
+	RunJetTestWithSet(t, set, nil, "World", "wcontext", "", "Hi, Buddy!\nHi, World!")
 }
 
 func TestIncludeIfNotExists(t *testing.T) {


### PR DESCRIPTION
Together with a tool like `vfsgen` this can be used to embed the templates into the compiled go binary. This makes deployments simpler and faster but should be used in conjunction with the development mode and a stubbed (read: nil) http.FileSystem.
