### PR TITLE
Improve custom loaders

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -40,19 +40,19 @@ type hasAddGopathPath interface {
 	AddGopathPath(path string)
 }
 
-// osFileSystemLoader implements Loader interface using OS file system (os.File).
-type osFileSystemLoader struct {
+// OSFileSystemLoader implements Loader interface using OS file system (os.File).
+type OSFileSystemLoader struct {
 	dirs []string
 }
 
 // Open opens a file from OS file system.
-func (l *osFileSystemLoader) Open(name string) (io.ReadCloser, error) {
+func (l *OSFileSystemLoader) Open(name string) (io.ReadCloser, error) {
 	return os.Open(name)
 }
 
 // Exists checks if the template name exists by walking the list of template paths
 // returns string with the full path of the template and bool true if the template file was found
-func (l *osFileSystemLoader) Exists(name string) (string, bool) {
+func (l *OSFileSystemLoader) Exists(name string) (string, bool) {
 	for i := 0; i < len(l.dirs); i++ {
 		fileName := path.Join(l.dirs[i], name)
 		if _, err := os.Stat(fileName); err == nil {
@@ -62,11 +62,14 @@ func (l *osFileSystemLoader) Exists(name string) (string, bool) {
 	return "", false
 }
 
-func (l *osFileSystemLoader) AddPath(path string) {
+// AddPath adds the path to the internal list of paths searched when loading templates.
+func (l *OSFileSystemLoader) AddPath(path string) {
 	l.dirs = append(l.dirs, path)
 }
 
-func (l *osFileSystemLoader) AddGopathPath(path string) {
+// AddGopathPath adds a path located in the GOPATH.
+// Example: l.AddGopathPath("github.com/CloudyKit/jet/example/views")
+func (l *OSFileSystemLoader) AddGopathPath(path string) {
 	paths := filepath.SplitList(os.Getenv("GOPATH"))
 	for i := 0; i < len(paths); i++ {
 		path, err := filepath.Abs(filepath.Join(paths[i], "src", path))

--- a/loader.go
+++ b/loader.go
@@ -72,7 +72,8 @@ func (l *OSFileSystemLoader) AddPath(path string) {
 func (l *OSFileSystemLoader) AddGopathPath(path string) {
 	paths := filepath.SplitList(os.Getenv("GOPATH"))
 	for i := 0; i < len(paths); i++ {
-		path, err := filepath.Abs(filepath.Join(paths[i], "src", path))
+		var err error
+		path, err = filepath.Abs(filepath.Join(paths[i], "src", path))
 		if err != nil {
 			panic(errors.New("Can't add this path err: " + err.Error()))
 		}

--- a/loaders/httpfs/loader.go
+++ b/loaders/httpfs/loader.go
@@ -1,31 +1,36 @@
 package httpfs
 
 import (
-	"github.com/CloudyKit/jet"
 	"io"
 	"net/http"
+	"os"
+
+	"github.com/CloudyKit/jet"
 )
 
 type httpFileSystemLoader struct {
-	http.FileSystem
+	fs http.FileSystem
 }
 
+// NewLoader returns an initialized loader serving the passed http.FileSystem.
 func NewLoader(fs http.FileSystem) jet.Loader {
-	return httpFileSystemLoader{FileSystem: fs}
+	return &httpFileSystemLoader{fs: fs}
 }
 
-func (l httpFileSystemLoader) Open(name string) (io.ReadCloser, error) {
-	f, err := l.FileSystem.Open(name)
-	return f, err
+// Open opens the file via the internal http.FileSystem. It is the callers duty to close the file.
+func (l *httpFileSystemLoader) Open(name string) (io.ReadCloser, error) {
+	return l.fs.Open(name)
 }
 
 // Exists checks if the template name exists by walking the list of template paths
 // returns string with the full path of the template and bool true if the template file was found
-func (l httpFileSystemLoader) Exists(name string) (string, bool) {
-	f, err := l.FileSystem.Open(name)
-	if err != nil {
+func (l *httpFileSystemLoader) Exists(name string) (string, bool) {
+	if l.fs == nil {
 		return "", false
 	}
-	f.Close()
-	return name, true
+	if f, err := l.Open(name); err == nil {
+		f.Close()
+		return name, true
+	}
+	return "", false
 }

--- a/loaders/httpfs/loader.go
+++ b/loaders/httpfs/loader.go
@@ -19,6 +19,9 @@ func NewLoader(fs http.FileSystem) jet.Loader {
 
 // Open opens the file via the internal http.FileSystem. It is the callers duty to close the file.
 func (l *httpFileSystemLoader) Open(name string) (io.ReadCloser, error) {
+	if l.fs == nil {
+		return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrNotExist}
+	}
 	return l.fs.Open(name)
 }
 

--- a/loaders/multi/multi.go
+++ b/loaders/multi/multi.go
@@ -1,0 +1,50 @@
+package multi
+
+import (
+	"io"
+	"os"
+
+	"github.com/CloudyKit/jet"
+)
+
+// Multi implements jet.Loader interface and tries to load templates from a list of custom loaders.
+type Multi struct {
+	loaders []jet.Loader
+}
+
+// NewLoader returns a new multi loader. The order of the loaders passed as parameters
+// will define the order in which templates are loaded.
+func NewLoader(loaders ...jet.Loader) *Multi {
+	return &Multi{loaders: loaders}
+}
+
+// AddLoaders adds the passed loaders to the list of loaders.
+func (m *Multi) AddLoaders(loaders ...jet.Loader) {
+	m.loaders = append(m.loaders, loaders...)
+}
+
+// ClearLoaders clears the list of loaders.
+func (m *Multi) ClearLoaders() {
+	m.loaders = nil
+}
+
+// Open will open the file passed by trying all loaders in succession.
+func (m *Multi) Open(name string) (io.ReadCloser, error) {
+	for _, loader := range m.loaders {
+		if f, err := loader.Open(name); err == nil {
+			return f, nil
+		}
+	}
+	return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrNotExist}
+}
+
+// Exists checks all loaders in succession, returning the full path of the template and
+// bool true if the template file was found, otherwise it returns an empty string and false.
+func (m *Multi) Exists(name string) (string, bool) {
+	for _, loader := range m.loaders {
+		if fileName, ok := loader.Exists(name); ok {
+			return fileName, true
+		}
+	}
+	return "", false
+}

--- a/template.go
+++ b/template.go
@@ -83,7 +83,7 @@ func NewHTMLSetLoader(loader Loader) *Set {
 
 // NewSet creates a new set, dirs is a list of directories to be searched for templates
 func NewSet(escapee SafeWriter, dirs ...string) *Set {
-	return NewSetLoader(escapee, &osFileSystemLoader{dirs: dirs})
+	return NewSetLoader(escapee, &OSFileSystemLoader{dirs: dirs})
 }
 
 // NewHTMLSet creates a new set, dirs is a list of directories to be searched for templates


### PR DESCRIPTION
I got to play around with the new loaders you guys added in #48 and there are a few things that caught my eye while switching from my naive implementation (the one in #37).

Because we're always loading templates from the file system in development and only switch to a binary packaged `http.FileSystem` I needed to copy over your `osFileSystemLoader` implementation – it wasn't exported so I couldn't instantiate it myself. That made me write another custom loader to stitch that and the `httpfs` loader together. All in all I felt like this could be improved so here goes:
1. I made the `osFileSystemLoader` public so it can be used on its own and I didn't see any disadvantage in keeping this private to the library.
2. I added a simple multi loader implementation that is still a `jet.Loader` but can be used with a list of custom loaders.

Now, would you accept this into the core? I don't want to continue with it if you aren't.

If you are, however, then I'd like to polish it with some tests, a nice example of using `vfsgen` in an app that loads templates from the file system in development but switches to a packaged `http.FileSystem` when compiled and also add a bit of documentation of how to use this to the wiki.