### PR TITLE
Run TravisCI tests in Go 1.8 and 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
- - 1.6.2
- - tip
+ - 1.8
+ - 1.9
 
 script:
  - go test -v ./...


### PR DESCRIPTION
This fixes #69 and follows the larger Go community's guidelines.