### PR TITLE
Support platform-appropriate path-separators

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -108,7 +108,7 @@ func RunJetTestWithSet(t *testing.T, set *Set, variables VarMap, context interfa
 	}
 
 	if err != nil {
-		t.Errorf("Parsing error: %s %s %s", err.Error(), testName, testContent)
+		t.Errorf("Parsing error: `%s` in test `%s` of content `%s`", err.Error(), testName, testContent)
 		return
 	}
 	RunJetTestWithTemplate(t, tt, variables, context, testExpected)

--- a/loader.go
+++ b/loader.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -59,7 +58,7 @@ func (l *OSFileSystemLoader) Open(name string) (io.ReadCloser, error) {
 // returns string with the full path of the template and bool true if the template file was found
 func (l *OSFileSystemLoader) Exists(name string) (string, bool) {
 	for i := 0; i < len(l.dirs); i++ {
-		fileName := path.Join(l.dirs[i], name)
+		fileName := filepath.Join(l.dirs[i], name)
 		if _, err := os.Stat(fileName); err == nil {
 			return fileName, true
 		}

--- a/template.go
+++ b/template.go
@@ -22,7 +22,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"path"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -143,9 +144,9 @@ func (s *Set) resolveName(name string) (newName, fileName string, foundLoaded, f
 
 func (s *Set) resolveNameSibling(name, sibling string) (newName, fileName string, foundLoaded, foundFile, isRelativeName bool) {
 	if sibling != "" {
-		i := strings.LastIndex(sibling, "/")
+		i := strings.LastIndex(sibling, pathSep)
 		if i != -1 {
-			if newName, fileName, foundLoaded, foundFile = s.resolveName(path.Join(sibling[:i+1], name)); foundFile || foundLoaded {
+			if newName, fileName, foundLoaded, foundFile = s.resolveName(filepath.Join(sibling[:i+1], name)); foundFile || foundLoaded {
 				isRelativeName = true
 				return
 			}
@@ -181,7 +182,7 @@ func (s *Set) loadFromFile(name, fileName string) (template *Template, err error
 }
 
 func (s *Set) getTemplateWhileParsing(parentName, name string) (template *Template, err error) {
-	name = path.Clean(name)
+	name = filepath.Clean(name)
 
 	if s.developmentMode {
 		if newName, fileName, _, foundPath, _ := s.resolveNameSibling(name, parentName); foundPath {
@@ -211,7 +212,7 @@ func (s *Set) getTemplateWhileParsing(parentName, name string) (template *Templa
 
 // getTemplate gets a template already loaded by name
 func (s *Set) getTemplate(name, sibling string) (template *Template, err error) {
-	name = path.Clean(name)
+	name = filepath.Clean(name)
 
 	if s.developmentMode {
 		s.tmx.RLock()
@@ -401,3 +402,5 @@ func (t *Template) ExecuteI18N(translator Translator, w io.Writer, variables Var
 	st.executeList(t.Root)
 	return
 }
+
+const pathSep = string(os.PathSeparator)


### PR DESCRIPTION
Changes `"path"` to `"path/filepath"` wherever it's imported (in `loader.go` and `template.go`) to support platform-dependent path-separators. Previously, Windows-style paths would cause template load errors on relative imports because `"/"` was hardcoded as the path separator in `template.go`:L147, causing `include` and `extends` statements to not correctly find sibling-files.

Also improves the error messages in `eval_test.go`.