### PR TITLE
Run test suite on Windows via AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jet Template Engine for Go [![Build Status](https://travis-ci.org/CloudyKit/jet.svg?branch=master)](https://travis-ci.org/CloudyKit/jet) [![Build status](https://ci.appveyor.com/api/projects/status/5g4whw3c6518vvku?svg=true)](https://ci.appveyor.com/project/CloudyKit/jet)
 
-[![Join the chat at https://gitter.im/CloudyKit/jet](https://badges.gitter.im/CloudyKit/jet.svg)](https://gitter.im/CloudyKit/jet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/CloudyKit/jet](https://badges.gitter.im/CloudyKit/jet.svg)](https://gitter.im/CloudyKit/jet)
 
 Jet is a template engine developed to be easy to use, powerful, dynamic, yet secure and very fast.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jet Template Engine for Go [![Build Status](https://travis-ci.org/CloudyKit/jet.svg?branch=master)](https://travis-ci.org/CloudyKit/jet)
+# Jet Template Engine for Go [![Build Status](https://travis-ci.org/CloudyKit/jet.svg?branch=master)](https://travis-ci.org/CloudyKit/jet) [![Build status](https://ci.appveyor.com/api/projects/status/5g4whw3c6518vvku?svg=true)](https://ci.appveyor.com/project/CloudyKit/jet)
 
 [![Join the chat at https://gitter.im/CloudyKit/jet](https://badges.gitter.im/CloudyKit/jet.svg)](https://gitter.im/CloudyKit/jet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,3 +22,13 @@ build: off
 
 test_script:
   - go test -v ./...
+  - cd examples/asset_packaging/
+  - go get -u github.com/shurcooL/vfsgen
+  - go generate
+  - go build -tags=deploy_build -o bin/app main.go
+  - cd bin
+  - ls -la
+  - START /B app.exe
+  - ps: $curl = curl http://localhost:9090
+  - ps: $curl
+  - ps: if ($curl.StatusCode -ne 200) { $host.SetShouldExit(1) }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+clone_folder: c:\gopath\src\github.com\CloudyKit\jet
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - echo %PATH%
+  - echo %GOPATH%
+  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
+  - go version
+  - go env

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,10 @@ version: "{build}"
 
 os: Windows Server 2012 R2
 
+# scripts that are called at very beginning, before repo cloning
+init:
+  - git config --global core.autocrlf true
+
 clone_folder: c:\gopath\src\github.com\CloudyKit\jet
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,12 +23,8 @@ build: off
 test_script:
   - go test -v ./...
   - cd examples/asset_packaging/
+  - go run main.go --run-and-exit
   - go get -u github.com/shurcooL/vfsgen
   - go generate
-  - go build -tags=deploy_build -o bin/app main.go
-  - cd bin
-  - ls -la
-  - START /B app.exe
-  - ps: $curl = curl http://localhost:9090
-  - ps: $curl
-  - ps: if ($curl.StatusCode -ne 200) { $host.SetShouldExit(1) }
+  - go build -tags=deploy_build -o bin/app.exe main.go
+  - .\bin\app.exe --run-and-exit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,15 @@ clone_folder: c:\gopath\src\github.com\CloudyKit\jet
 
 environment:
   GOPATH: c:\gopath
+  matrix:
+    - GOVERSION: 19
+    - GOVERSION: 110
 
 install:
+  - set PATH=%GOPATH%\bin;c:\go%GOVERSION%\bin;%PATH%
+  - set GOROOT=c:\go%GOVERSION%
   - echo %PATH%
   - echo %GOPATH%
-  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - go version
   - go env
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,3 +13,6 @@ install:
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - go version
   - go env
+
+test_script:
+  - go test -v ./...

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,5 +14,7 @@ install:
   - go version
   - go env
 
+build: off
+
 test_script:
   - go test -v ./...

--- a/eval_test.go
+++ b/eval_test.go
@@ -121,13 +121,13 @@ func RunJetTestWithTemplate(t *testing.T, tt *Template, variables VarMap, contex
 		{
 			Name: fmt.Sprintf("\tJetTest(%s)", tt.Name),
 			F: func(t *testing.T) {
-				buff := bytes.NewBuffer(nil)
-				err := tt.Execute(buff, variables, context)
+				var buf bytes.Buffer
+				err := tt.Execute(&buf, variables, context)
 				if err != nil {
 					t.Errorf("Eval error: %q executing %s", err.Error(), tt.Name)
 					return
 				}
-				result := buff.String()
+				result := strings.Replace(buf.String(), "\r\n", "\n", -1)
 				if result != testExpected {
 					t.Errorf("Result error expected %q got %q on %s", testExpected, result, tt.Name)
 				}

--- a/examples/asset_packaging/Makefile
+++ b/examples/asset_packaging/Makefile
@@ -1,8 +1,11 @@
 run:
 	go run main.go
 
+deps:
+	go get -u github.com/shurcooL/vfsgen
+
 build:
 	go generate
-	go build -tags=deploy_build -o app main.go
+	go build -tags=deploy_build -o bin/app main.go
 
-.PHONY: run build
+.PHONY: run build deps

--- a/examples/asset_packaging/views/includes/_partial.jet
+++ b/examples/asset_packaging/views/includes/_partial.jet
@@ -1,0 +1,1 @@
+<p>Included partial</p>

--- a/examples/asset_packaging/views/includes/blocks.jet
+++ b/examples/asset_packaging/views/includes/blocks.jet
@@ -1,0 +1,3 @@
+{{block menu()}}
+  <p>The menu block was invoked.</p>
+{{end}}

--- a/examples/asset_packaging/views/index.jet
+++ b/examples/asset_packaging/views/index.jet
@@ -1,5 +1,16 @@
 {{extends "layouts/application.jet"}}
+{{import "includes/blocks.jet"}}
 
 {{block documentBody()}}
   <h1>Asset Packaging example</h1>
+
+  <nav>
+    {{yield menu()}}
+  </nav>
+
+  {{include "includes/_partial.jet"}}
+
+  {{if !includeIfExists("doesNotExist.jet")}}
+    <p>doesNotExist.jet was not included because it doesn't exist.</p>
+  {{end}}
 {{end}}

--- a/jettest/test.go
+++ b/jettest/test.go
@@ -17,8 +17,10 @@ package jettest
 import (
 	"bytes"
 	"fmt"
-	"github.com/CloudyKit/jet"
+	"strings"
 	"testing"
+
+	"github.com/CloudyKit/jet"
 )
 
 // TestingSet holds a template set for running tests
@@ -58,13 +60,13 @@ func RunWithTemplate(t *testing.T, tt *jet.Template, variables jet.VarMap, conte
 		{
 			Name: fmt.Sprintf("\tJetTest(%s)", tt.Name),
 			F: func(t *testing.T) {
-				buff := bytes.NewBuffer(nil)
-				err := tt.Execute(buff, variables, context)
+				var buf bytes.Buffer
+				err := tt.Execute(&buf, variables, context)
 				if err != nil {
 					t.Errorf("Eval error: %q executing %s", err.Error(), tt.Name)
 					return
 				}
-				result := buff.String()
+				result := strings.Replace(buf.String(), "\r\n", "\n", -1)
 				if result != testExpected {
 					t.Errorf("Result error expected %q got %q on %s", testExpected, result, tt.Name)
 				}

--- a/parse_test.go
+++ b/parse_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"path"
+	"strings"
 	"testing"
 )
 
@@ -33,7 +34,8 @@ func (t ParserTestCase) ExpectPrintName(name, input, output string) {
 		t.Errorf("%q %s", input, err.Error())
 		return
 	}
-	expected := template.String()
+	expected := strings.Replace(template.String(), "\r\n", "\n", -1)
+	output = strings.Replace(output, "\r\n", "\n", -1)
 	if expected != output {
 		t.Errorf("Unexpected tree on %s Got:\n%s\nExpected: \n%s\n", name, expected, output)
 	}


### PR DESCRIPTION
I finally got around to adding AppVeyor for running the test suite on Windows in our PRs. It's especially related to #78. The good news is that Jet already works correctly on Windows. :+1: AppVeyor is free for open source projects.

I marked it as a work-in-progress because there's a few issues we still need to discuss:
- [x] Windows normally have Git's `core.autocrlf` set to auto which breaks our tests because the template comparisons are done verbatim and Windows has CRLF line endings, while the rendered templates in memory only have LF. I worked around this using a crude string replace (see code, ugh). The other way would be to set `core.autocrlf` to `input` and then it'll work.
- [x] As an addition I enhanced the asset packaging example to also be executed in AppVeyor to test a real app (both using the compiled version as well as just using `go run`) – thought that'd be good.
- [x] AppVeyor needs to be enabled in the CloudyKit organization.
- [x] Adding additional Go versions (the last two) via the matrix feature of AppVeyor.