### PR TITLE
Implement multiline handling for yield/block/function definitions

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -243,6 +243,37 @@ func TestEvalBlockYieldIncludeNode(t *testing.T) {
 		`{{import "BlockContentLib"}}{{yield row(cols="12") content}}{{cols}}{{end}}`,
 		"\n    <div class=\"row\">\n        \n            \n    <div class=\"col 12\">12</div>\n\n        \n    </div>\n")
 
+	JetTestingSet.LoadTemplate("BlockContentLib2", `
+		{{block col(
+			columns,
+		)}}
+			<div class="col {{columns}}">{{yield content}}</div>
+		{{end}}
+		{{block row(
+			cols="",
+			rowClass="",
+		)}}
+			<div class="row {{ rowClass }}">
+				{{if len(cols) > 0}}
+					{{yield col(columns=cols) content}}
+						{{yield content}}
+					{{end}}
+				{{else}}
+					{{yield content}}
+				{{end}}
+			</div>
+		{{end}}
+	`)
+	RunJetTest(t, nil, nil, "BlockContentParam2",
+		`{{import "BlockContentLib2"}}
+		{{yield row(
+			cols="12",
+			rowClass="highlight-row",
+		) content}}
+			{{cols}}
+		{{end}}`,
+		"\n\t\t\t<div class=\"row highlight-row\">\n\t\t\t\t\n\t\t\t\t\t\n\t\t\t<div class=\"col 12\">\n\t\t\t\t\t\t\n\t\t\t12\n\t\t\n\t\t\t\t\t</div>\n\t\t\n\t\t\t\t\n\t\t\t</div>\n\t\t",
+	)
 }
 
 func TestEvalRangeNode(t *testing.T) {

--- a/eval_test.go
+++ b/eval_test.go
@@ -302,6 +302,14 @@ func TestEvalDefaultFuncs(t *testing.T) {
 	RunJetTest(t, nil, &User{"Mario Santos", "mario@gmail.com"}, "DefaultFuncs_json", `{{. |writeJson}}`, "{\"Name\":\"Mario Santos\",\"Email\":\"mario@gmail.com\"}\n")
 
 	RunJetTest(t, nil, nil, "DefaultFuncs_replace", `{{replace("My Name Is", " ", "_", -1)}}`, "My_Name_Is")
+	RunJetTest(t, nil, nil, "DefaultFuncs_replace_multiline_statement",
+		`{{replace("My Name Is II",
+			" ",
+			"_",
+			-1
+		)}}`,
+		"My_Name_Is_II",
+	)
 }
 
 func TestEvalIssetAndTernaryExpression(t *testing.T) {

--- a/eval_test.go
+++ b/eval_test.go
@@ -306,7 +306,7 @@ func TestEvalDefaultFuncs(t *testing.T) {
 		`{{replace("My Name Is II",
 			" ",
 			"_",
-			-1
+			-1,
 		)}}`,
 		"My_Name_Is_II",
 	)

--- a/lex.go
+++ b/lex.go
@@ -72,7 +72,7 @@ const (
 	itemLess
 	itemLessEquals
 	itemComma
-	itemColonComma
+	itemSemicolon
 	itemAdd
 	itemMinus
 	itemMul
@@ -330,7 +330,7 @@ func lexInsideAction(l *lexer) stateFn {
 	case r == ',':
 		l.emit(itemComma)
 	case r == ';':
-		l.emit(itemColonComma)
+		l.emit(itemSemicolon)
 	case r == '*':
 		l.emit(itemMul)
 	case r == '/':

--- a/lex.go
+++ b/lex.go
@@ -323,9 +323,9 @@ func lexInsideAction(l *lexer) stateFn {
 		return l.errorf("unclosed left paren")
 	}
 	switch r := l.next(); {
-	case r == eof || isEndOfLine(r):
+	case r == eof:
 		return l.errorf("unclosed action")
-	case isSpace(r):
+	case isSpace(r), isEndOfLine(r):
 		return lexSpace
 	case r == ',':
 		l.emit(itemComma)

--- a/lex.go
+++ b/lex.go
@@ -325,7 +325,7 @@ func lexInsideAction(l *lexer) stateFn {
 	switch r := l.next(); {
 	case r == eof:
 		return l.errorf("unclosed action")
-	case isSpace(r), isEndOfLine(r):
+	case isSpace(r):
 		return lexSpace
 	case r == ',':
 		l.emit(itemComma)
@@ -536,7 +536,7 @@ func lexField(l *lexer) stateFn {
 // day to implement arithmetic.
 func (l *lexer) atTerminator() bool {
 	r := l.peek()
-	if isSpace(r) || isEndOfLine(r) {
+	if isSpace(r) {
 		return true
 	}
 	switch r {
@@ -649,12 +649,7 @@ Loop:
 
 // isSpace reports whether r is a space character.
 func isSpace(r rune) bool {
-	return r == ' ' || r == '\t'
-}
-
-// isEndOfLine reports whether r is an end-of-line character.
-func isEndOfLine(r rune) bool {
-	return r == '\r' || r == '\n'
+	return r == ' ' || r == '\t' || r == '\r' || r == '\n'
 }
 
 // isAlphaNumeric reports whether r is an alphabetic, digit, or underscore.

--- a/lex_test.go
+++ b/lex_test.go
@@ -16,16 +16,16 @@ package jet
 
 import "testing"
 
-func lexerTestCase(t *testing.T, input string, itens ...itemType) {
+func lexerTestCase(t *testing.T, input string, items ...itemType) {
 	lexer := lex("test.flowRender", input)
-	for i := 0; i < len(itens); i++ {
+	for i := 0; i < len(items); i++ {
 		item := lexer.nextItem()
 
 		for item.typ == itemSpace {
 			item = lexer.nextItem()
 		}
 
-		if item.typ != itens[i] {
+		if item.typ != items[i] {
 			t.Errorf("Unexpected token %s on input on %q => %q", item, input, input[item.pos:])
 			return
 		}

--- a/lex_test.go
+++ b/lex_test.go
@@ -57,7 +57,6 @@ func TestLexer(t *testing.T) {
 }
 
 func TestLexNegatives(t *testing.T) {
-
 	lexerTestCase(t, `{{ -1 }}`, itemLeftDelim, itemNumber, itemRightDelim)
 	lexerTestCase(t, `{{ 5 + -1 }}`, itemLeftDelim, itemNumber, itemAdd, itemNumber, itemRightDelim)
 	lexerTestCase(t, `{{ 5 * -1 }}`, itemLeftDelim, itemNumber, itemMul, itemNumber, itemRightDelim)

--- a/parse.go
+++ b/parse.go
@@ -827,6 +827,9 @@ func (t *Template) parseArguments() (args []Expression) {
 			args = append(args, expr)
 			switch endtoken.typ {
 			case itemComma:
+				if t.peekNonSpace().typ == itemRightParen {
+					break loop
+				}
 				continue loop
 			default:
 				t.backup()

--- a/parse.go
+++ b/parse.go
@@ -504,7 +504,7 @@ func (t *Template) action() (n Node) {
 		action.Set = expr.(*SetNode)
 		expr = nil
 	}
-	if action.Set == nil || t.expectOneOf(itemColonComma, itemRightDelim, "command").typ == itemColonComma {
+	if action.Set == nil || t.expectOneOf(itemSemicolon, itemRightDelim, "command").typ == itemSemicolon {
 		action.Pipe = t.pipeline("command", expr)
 	}
 	return action
@@ -862,7 +862,7 @@ func (t *Template) parseControl(allowElseIf bool, context string) (pos Pos, line
 	if expression.Type() == NodeSet {
 		set = expression.(*SetNode)
 		if context != "range" {
-			t.expect(itemColonComma, context)
+			t.expect(itemSemicolon, context)
 			expression = t.expression(context)
 		} else {
 			expression = nil

--- a/testData/new_block_yield.jet
+++ b/testData/new_block_yield.jet
@@ -3,8 +3,12 @@
     {{label}}: <input type="text" name="{{name}}" value="{{value}}" />
 {{ end }}
 
-{{ block col(md=12,offset=0) }}
-    <div class="col-md-{{size}} col-md-offset-{{offset}}">{{ yield content }}</div>
+{{ block col(
+  md=12,
+  offset=0,
+  additionalClass=""
+) }}
+    <div class="col-md-{{size}} col-md-offset-{{offset}} {{additionalClass}}">{{ yield content }}</div>
 {{ end }}
 
 {{ block row() .}}
@@ -17,7 +21,9 @@
 
 {{ block header() }}
     {{ yield row() content}}
-        {{ yield col(md=6) content }}
+        {{ yield col(md=6,
+          additionalClass="center"
+        ) content }}
 {{ yield content }}
         {{end}}
     {{end}}
@@ -31,8 +37,8 @@
     {{label}}: <input type="text" name="{{name}}" value="{{value}}" />
 {{end}}
 
-{{block col(md=12,offset=0)}}
-    <div class="col-md-{{size}} col-md-offset-{{offset}}">{{yield content}}</div>
+{{block col(md=12,offset=0,additionalClass="")}}
+    <div class="col-md-{{size}} col-md-offset-{{offset}} {{additionalClass}}">{{yield content}}</div>
 {{end}}
 
 {{block row() .}}
@@ -45,7 +51,7 @@
 
 {{block header()}}
     {{yield row() content}}
-        {{yield col(md=6) content}}
+        {{yield col(md=6,additionalClass="center") content}}
 {{yield content}}
         {{end}}
     {{end}}

--- a/testData/range.jet
+++ b/testData/range.jet
@@ -1,6 +1,8 @@
 {{ range coditionEe }}{{ end }}
 {{ range coditionEe.Field }}{{ end }}
-{{ range coditionEe.Method(value) }}{{ end }}
+{{ range coditionEe.Method(
+  value
+) }}{{ end }}
 {{ range coditionEe.Method(value) }} {{ else }} {{ end }}
 {{ range index,value = coditionEe.Method(value) }} {{ else }} {{ end }}
 {{ range value := coditionEe.Method(value) }} {{ else }} {{ end }}


### PR DESCRIPTION
This fixes #86 but isn't just for `yield`s but because the parser easily handles this as "inside-actions" it's now also possible when invoking functions and defining blocks.

As a quick example these would have failed with `unclosed action` before but work now:

```
{{block col(
	columns,
)}}
	…

{{yield row(
	cols="12",
	rowClass="highlight-row",
) content}}

{{replace("My Name Is II",
	" ",
	"_",
	-1,
)}}
```

Edit: the edge case below is fixed.

I noticed one edge case:
```
{{replace("My Name Is II",
	" ",
	"_",
	-1,
)}}
```

~Here the dangling comma after the -1 trips up the parser and it fails with `unexpected token ")" on operand` because it expects the decimal number to continue. One way to fix it is to disallow dangling commas (which are actually a side effect of the lexer) but that syntax feels very Go-like. This edge case fails when parsing the template so it's not a runtime failure upon template execution so I'd like to keep it if we can live with it.~