### PR TITLE
Add ability to use custom delimiters

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -235,7 +235,7 @@ func (l *lexer) drain() {
 }
 
 // lex creates a new scanner for the input string.
-func lex(name, input string) *lexer {
+func lex(name, input string, run bool) *lexer {
 	l := &lexer{
 		name:       name,
 		input:      input,
@@ -243,16 +243,20 @@ func lex(name, input string) *lexer {
 		leftDelim:  defaultLeftDelim,
 		rightDelim: defaultRightDelim,
 	}
-	go l.run()
+	if run {
+		l.run()
+	}
 	return l
 }
 
 // run runs the state machine for the lexer.
 func (l *lexer) run() {
-	for l.state = lexText; l.state != nil; {
-		l.state = l.state(l)
-	}
-	close(l.items)
+	go func() {
+		for l.state = lexText; l.state != nil; {
+			l.state = l.state(l)
+		}
+		close(l.items)
+	}()
 }
 
 // state functions

--- a/lex.go
+++ b/lex.go
@@ -127,6 +127,13 @@ var key = map[string]itemType{
 
 const eof = -1
 
+const (
+	defaultLeftDelim  = "{{"
+	defaultRightDelim = "}}"
+	leftComment       = "{*"
+	rightComment      = "*}"
+)
+
 // stateFn represents the state of the scanner as a function that returns the next state.
 type stateFn func(*lexer) stateFn
 
@@ -142,6 +149,8 @@ type lexer struct {
 	items      chan item // channel of scanned items
 	parenDepth int       // nesting depth of ( ) exprs
 	lastType   itemType
+	leftDelim  string
+	rightDelim string
 }
 
 // next returns the next rune in the input.
@@ -227,11 +236,12 @@ func (l *lexer) drain() {
 
 // lex creates a new scanner for the input string.
 func lex(name, input string) *lexer {
-
 	l := &lexer{
-		name:  name,
-		input: input,
-		items: make(chan item),
+		name:       name,
+		input:      input,
+		items:      make(chan item),
+		leftDelim:  defaultLeftDelim,
+		rightDelim: defaultRightDelim,
 	}
 	go l.run()
 	return l
@@ -244,13 +254,6 @@ func (l *lexer) run() {
 	}
 	close(l.items)
 }
-
-const (
-	leftDelim    = "{{"
-	rightDelim   = "}}"
-	leftComment  = "{*"
-	rightComment = "*}"
-)
 
 // state functions
 func lexText(l *lexer) stateFn {

--- a/lex_test.go
+++ b/lex_test.go
@@ -41,6 +41,13 @@ func lexerTestCase(t *testing.T, input string, items ...itemType) {
 	lexerTestCaseCustomLexer(t, lexer, input, items...)
 }
 
+func lexerTestCaseCustomDelimiters(t *testing.T, leftDelim, rightDelim, input string, items ...itemType) {
+	lexer := lex("test.customDelimiters", input, false)
+	lexer.setDelimiters(leftDelim, rightDelim)
+	lexer.run()
+	lexerTestCaseCustomLexer(t, lexer, input, items...)
+}
+
 func TestLexer(t *testing.T) {
 	lexerTestCase(t, `{{}}`, itemLeftDelim, itemRightDelim)
 	lexerTestCase(t, `{{ line }}`, itemLeftDelim, itemIdentifier, itemRightDelim)
@@ -58,7 +65,25 @@ func TestLexer(t *testing.T) {
 	lexerTestCase(t, `{{.Ex!1}}`, itemLeftDelim, itemField, itemNot, itemNumber, itemRightDelim)
 	lexerTestCase(t, `{{.Ex==1}}`, itemLeftDelim, itemField, itemEquals, itemNumber, itemRightDelim)
 	lexerTestCase(t, `{{.Ex&&1}}`, itemLeftDelim, itemField, itemAnd, itemNumber, itemRightDelim)
+}
 
+func TestCustomDelimiters(t *testing.T) {
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[]]`, itemLeftDelim, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[ line ]]`, itemLeftDelim, itemIdentifier, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[ . ]]`, itemLeftDelim, itemIdentifier, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[ .Field ]]`, itemLeftDelim, itemField, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[ "value" ]]`, itemLeftDelim, itemString, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[ call: value ]]`, itemLeftDelim, itemIdentifier, itemColon, itemIdentifier, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[.Ex+1]]`, itemLeftDelim, itemField, itemAdd, itemNumber, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[.Ex-1]]`, itemLeftDelim, itemField, itemMinus, itemNumber, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[.Ex*1]]`, itemLeftDelim, itemField, itemMul, itemNumber, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[.Ex/1]]`, itemLeftDelim, itemField, itemDiv, itemNumber, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[.Ex%1]]`, itemLeftDelim, itemField, itemMod, itemNumber, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[.Ex=1]]`, itemLeftDelim, itemField, itemAssign, itemNumber, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[Ex:=1]]`, itemLeftDelim, itemIdentifier, itemAssign, itemNumber, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[.Ex!1]]`, itemLeftDelim, itemField, itemNot, itemNumber, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[.Ex==1]]`, itemLeftDelim, itemField, itemEquals, itemNumber, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[.Ex&&1]]`, itemLeftDelim, itemField, itemAnd, itemNumber, itemRightDelim)
 }
 
 func TestLexNegatives(t *testing.T) {
@@ -73,4 +98,5 @@ func TestLexNegatives(t *testing.T) {
 
 func TestLexer_Bug35(t *testing.T) {
 	lexerTestCase(t, `{{if x>y}}blahblah...{{end}}`, itemLeftDelim, itemIf, itemIdentifier, itemGreat, itemIdentifier, itemRightDelim, itemText, itemLeftDelim, itemEnd, itemRightDelim)
+	lexerTestCaseCustomDelimiters(t, "[[", "]]", `[[if x>y]]blahblah...[[end]]`, itemLeftDelim, itemIf, itemIdentifier, itemGreat, itemIdentifier, itemRightDelim, itemText, itemLeftDelim, itemEnd, itemRightDelim)
 }

--- a/lex_test.go
+++ b/lex_test.go
@@ -16,8 +16,8 @@ package jet
 
 import "testing"
 
-func lexerTestCase(t *testing.T, input string, items ...itemType) {
-	lexer := lex("test.flowRender", input)
+func lexerTestCaseCustomLexer(t *testing.T, lexer *lexer, input string, items ...itemType) {
+	t.Helper()
 	for i := 0; i < len(items); i++ {
 		item := lexer.nextItem()
 
@@ -34,6 +34,11 @@ func lexerTestCase(t *testing.T, input string, items ...itemType) {
 	if item.typ != itemEOF {
 		t.Errorf("Unexpected token %s EOF is expected", item)
 	}
+}
+
+func lexerTestCase(t *testing.T, input string, items ...itemType) {
+	lexer := lex("test.flowRender", input, true)
+	lexerTestCaseCustomLexer(t, lexer, input, items...)
 }
 
 func TestLexer(t *testing.T) {

--- a/parse.go
+++ b/parse.go
@@ -167,7 +167,10 @@ func (s *Set) parse(name, text string) (t *Template, err error) {
 	defer t.recover(&err)
 
 	t.ParseName = t.Name
-	t.startParse(lex(t.Name, text))
+	lexer := lex(t.Name, text, false)
+	lexer.setDelimiters(s.leftDelim, s.rightDelim)
+	lexer.run()
+	t.startParse(lexer)
 	t.parseTemplate()
 	t.stopParse()
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -26,10 +26,15 @@ var parseSet = NewSet(nil, "./testData")
 
 type ParserTestCase struct {
 	*testing.T
+	set *Set
 }
 
 func (t ParserTestCase) ExpectPrintName(name, input, output string) {
-	template, err := parseSet.parse(name, input)
+	set := parseSet
+	if t.set != nil {
+		set = t.set
+	}
+	template, err := set.parse(name, input)
 	if err != nil {
 		t.Errorf("%q %s", input, err.Error())
 		return
@@ -60,36 +65,43 @@ func (t ParserTestCase) ExpectPrintSame(input string) {
 }
 
 func TestParseTemplateAndImport(t *testing.T) {
-	p := ParserTestCase{t}
+	p := ParserTestCase{T: t}
 	p.TestPrintFile("extends.jet")
 	p.TestPrintFile("imports.jet")
 }
 
 func TestParseTemplateControl(t *testing.T) {
-	p := ParserTestCase{t}
+	p := ParserTestCase{T: t}
 	p.TestPrintFile("if.jet")
 	p.TestPrintFile("range.jet")
 }
 
 func TestParseTemplateExpressions(t *testing.T) {
-	p := ParserTestCase{t}
+	p := ParserTestCase{T: t}
 	p.TestPrintFile("simple_expression.jet")
 	p.TestPrintFile("additive_expression.jet")
 	p.TestPrintFile("multiplicative_expression.jet")
 }
 
 func TestParseTemplateBlockYield(t *testing.T) {
-	p := ParserTestCase{t}
+	p := ParserTestCase{T: t}
 	p.TestPrintFile("block_yield.jet")
 	p.TestPrintFile("new_block_yield.jet")
 }
 
 func TestParseTemplateIndexSliceExpression(t *testing.T) {
-	p := ParserTestCase{t}
+	p := ParserTestCase{T: t}
 	p.TestPrintFile("index_slice_expression.jet")
 }
 
 func TestParseTemplateAssignment(t *testing.T) {
-	p := ParserTestCase{t}
+	p := ParserTestCase{T: t}
 	p.TestPrintFile("assignment.jet")
+}
+
+func TestParseTemplateWithCustomDelimiters(t *testing.T) {
+	set := NewSet(nil, "./testData")
+	set.Delims("[[", "]]")
+	p := ParserTestCase{T: t, set: set}
+	p.TestPrintFile("custom_delimiters.jet")
 }

--- a/template.go
+++ b/template.go
@@ -41,6 +41,8 @@ type Set struct {
 	gmx               *sync.RWMutex        // global variables map mutex
 	defaultExtensions []string
 	developmentMode   bool
+	leftDelim         string
+	rightDelim        string
 }
 
 // SetDevelopmentMode set's development mode on/off, in development mode template will be recompiled on every run
@@ -109,6 +111,13 @@ func (s *Set) AddGopathPath(path string) {
 	} else {
 		panic(fmt.Sprintf("AddGopathPath() not supported on custom loader of type %T", s.loader))
 	}
+}
+
+// Delims sets the delimiters to the specified strings. Parsed templates will
+// inherit the settings. Not setting them leaves them at the default: {{ or }}.
+func (s *Set) Delims(left, right string) {
+	s.leftDelim = left
+	s.rightDelim = right
 }
 
 // resolveName try to resolve a template name, the steps as follow

--- a/testData/custom_delimiters.jet
+++ b/testData/custom_delimiters.jet
@@ -1,0 +1,21 @@
+[[ . ]]
+[[ singleValue ]]
+[[ nil ]]
+[[ "" ]]
+[[ val.Field ]]
+[[ url: "" ]]
+[[ url: "","" |pipe ]]
+[[ url("") |pipe |pipe ]]
+[[ url("","").Field |pipe ]]
+[[ url("","").Method("") |pipe ]]
+===
+{{.}}
+{{singleValue}}
+{{nil}}
+{{""}}
+{{val.Field}}
+{{url:""}}
+{{url:"", "" | pipe}}
+{{url("") | pipe | pipe}}
+{{url("", "").Field | pipe}}
+{{url("", "").Method("") | pipe}}


### PR DESCRIPTION
This fixes #68 and introduces the ability to use custom delimiters.

Use like this:
```go
var View = jet.NewHTMLSet("./views"))
View.Delims("[[", "]]")
```

```html
<!-- file: "views/home.jet" -->
[[ extends "layouts/application.jet" ]]
[[ block body() ]]
  <main>
    This content will be yielded in the layout above.
  </main>
[[ end ]]
```

TODO:
- [x] test extensively
- [x] add documentation for it to the wiki

This fixes #68 and closes #98.