### PR TITLE
Added function to disable template rendering abort on error

### DIFF
--- a/global.go
+++ b/global.go
@@ -1,0 +1,9 @@
+package jet
+
+var abortTemplateOnError = true
+
+// SetAbortTemplateOnError controls whether the template rendering process should be aborted when an error is encountered.
+/// Default behavior is to abort the template rendering process when an error is encountered, so abortOnError == true.
+func SetAbortTemplateOnError(abortOnError bool) {
+	abortTemplateOnError = abortOnError
+}

--- a/node.go
+++ b/node.go
@@ -61,7 +61,9 @@ func (node *NodeBase) error(err error) {
 }
 
 func (node *NodeBase) errorf(format string, v ...interface{}) {
-	panic(fmt.Errorf("Jet Runtime Error(%q:%d): %s", node.TemplateName, node.Line, fmt.Sprintf(format, v...)))
+	if abortTemplateOnError {
+		panic(fmt.Errorf("Jet Runtime Error(%q:%d): %s", node.TemplateName, node.Line, fmt.Sprintf(format, v...)))
+	}
 }
 
 // Type returns itself and provides an easy default implementation


### PR DESCRIPTION
We are currently evaluating jet for use in our projects.

One thing that is different to a lot of other template languages (e. g. Handlebars) is how jet handles expressions that cannot be evaluated.

E. g. accessing a non-valid field value will lead to the whole template rendering process being aborted and the error being returned. Handlebars would just insert an empty string into the place of the expression.

To enable this "Handlebars"-like behavior with jet, I've added the `abortTemplateOnError` global variable that can be set from the outside via `SetAbortTemplateOnError`.

It works well with this template (`document.yada` is not set in this case, the if comparison is also not valid):

```
{{ document.title }}
{{ document.yada }}
{{ if "2006" < 2018 }}foooooooo{{end}}
{{ document.title }}
```

Do you see any problems with this? `Node.errorf` is used in a lot of other situations that I haven't checked so far.