### PR TITLE
make Ranger return interface{}, not reflect.Value

### DIFF
--- a/default.go
+++ b/default.go
@@ -65,7 +65,7 @@ func init() {
 			a.RequireNumOfArguments("len", 1, 1)
 
 			expression := a.Get(0)
-			if expression.Kind() == reflect.Ptr {
+			if expression.Kind() == reflect.Ptr || expression.Kind() == reflect.Interface {
 				expression = expression.Elem()
 			}
 

--- a/eval.go
+++ b/eval.go
@@ -650,21 +650,21 @@ func (st *Runtime) evalPrimaryExpressionGroup(node Expression) reflect.Value {
 	return st.evalBaseExpressionGroup(node)
 }
 
-func (st *Runtime) isSet(node Node) bool {
-	// notNil returns false when v.IsValid() == false
-	// or when v's kind can be nil and v.IsNil() == true
-	notNil := func(v reflect.Value) bool {
-		if !v.IsValid() {
-			return false
-		}
-		switch v.Kind() {
-		case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
-			return !v.IsNil()
-		default:
-			return true
-		}
+// notNil returns false when v.IsValid() == false
+// or when v's kind can be nil and v.IsNil() == true
+func notNil(v reflect.Value) bool {
+	if !v.IsValid() {
+		return false
 	}
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return !v.IsNil()
+	default:
+		return true
+	}
+}
 
+func (st *Runtime) isSet(node Node) bool {
 	nodeType := node.Type()
 
 	switch nodeType {

--- a/eval_test.go
+++ b/eval_test.go
@@ -460,6 +460,20 @@ func TestEvalBuiltinExpression(t *testing.T) {
 	RunJetTest(t, data, nil, "LenExpression_1", `{{len("111")}}`, "3")
 	RunJetTest(t, data, nil, "LenExpression_2", `{{isset(data)?len(data):0}}`, "0")
 	RunJetTest(t, data, []string{"", "", "", ""}, "LenExpression_3", `{{len(.)}}`, "4")
+	data.Set(
+		"foo", map[string]interface{}{
+			"asd": map[string]string{
+				"bar": "baz",
+			},
+		},
+	)
+	RunJetTest(t, data, nil, "IsSetExpression_1", `{{isset(foo)}}`, "true")
+	RunJetTest(t, data, nil, "IsSetExpression_2", `{{isset(foo.asd)}}`, "true")
+	RunJetTest(t, data, nil, "IsSetExpression_3", `{{isset(foo.asd.bar)}}`, "true")
+	RunJetTest(t, data, nil, "IsSetExpression_4", `{{isset(asd)}}`, "false")
+	RunJetTest(t, data, nil, "IsSetExpression_5", `{{isset(foo.bar)}}`, "false")
+	RunJetTest(t, data, nil, "IsSetExpression_6", `{{isset(foo.asd.foo)}}`, "false")
+	RunJetTest(t, data, nil, "IsSetExpression_7", `{{isset(foo.asd.bar.xyz)}}`, "false")
 }
 
 func TestEvalAutoescape(t *testing.T) {


### PR DESCRIPTION
Previously, the key/index and element values returned by Ranger were reflect.Values pointing to the underlying data (see https://golang.org/src/reflect/value.go?s=67137:67170#L2242 and https://golang.org/src/reflect/value.go#L140). This meant you could not compare e.g. elements of a string slice to a string literal. Also, storing a copy of a certain slice element's index and using it outside of the range did not work, since the copy only pointed to the actual index (which had the value len+1 after the range).