### PR TITLE
Misc fixes related to Ranger and pointer evaluation/printing

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -433,10 +433,6 @@ func TestEvalPointerLimitNumberOfDereferences(t *testing.T) {
 	j := &i
 	data.Set("intPointer", &j)
 	RunJetTest(t, data, nil, "IntPointer_j", `{{ intPointer }}`, "<nil>")
-
-	// k := &j
-	// data.Set("intPointer", &k)
-	// RunJetTest(t, data, nil, "IntPointer_1", `{{ intPointer }}`, "<nil>")
 }
 
 type Apple struct {

--- a/func.go
+++ b/func.go
@@ -26,6 +26,11 @@ type Arguments struct {
 	argVal  []reflect.Value
 }
 
+// IsSet checks whether an argument is set or not. It behaves like the build-in isset function.
+func (a *Arguments) IsSet(argumentIndex int) bool {
+	return a.runtime.isSet(a.argExpr[argumentIndex])
+}
+
 // Get gets an argument by index.
 func (a *Arguments) Get(argumentIndex int) reflect.Value {
 	if argumentIndex < len(a.argVal) {

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.12
 
 require github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a
 
-replace github.com/CloudyKit/fastprinter => github.com/annismckenzie/fastprinter v0.0.0-20180721091441-b9f2fb63ce50 // PR 1 at https://github.com/CloudyKit/fastprinter/pull/1
+replace github.com/CloudyKit/fastprinter => github.com/sauerbraten/fastprinter v0.0.0-20200109142611-26ce1e0b7924

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/CloudyKit/jet/v3
 
 go 1.12
 
-require github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a
-
-replace github.com/CloudyKit/fastprinter => github.com/sauerbraten/fastprinter v0.0.0-20200109142611-26ce1e0b7924
+require github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/annismckenzie/fastprinter v0.0.0-20180721091441-b9f2fb63ce50 h1:SOQHYHI8DAjvAA/j8JnGoJJNnRBQmMLlm24ey4GdFvY=
-github.com/annismckenzie/fastprinter v0.0.0-20180721091441-b9f2fb63ce50/go.mod h1:mALEYWfUtOXobHPI5r4jg8ZLRAXVUBiZGFtM3CTnYqg=
+github.com/sauerbraten/fastprinter v0.0.0-20200109142611-26ce1e0b7924 h1:xMgU9OEhUw9knBBibLHZgJ4uNPUlfBAYAsRHfH0P2jw=
+github.com/sauerbraten/fastprinter v0.0.0-20200109142611-26ce1e0b7924/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/sauerbraten/fastprinter v0.0.0-20200109142611-26ce1e0b7924 h1:xMgU9OEhUw9knBBibLHZgJ4uNPUlfBAYAsRHfH0P2jw=
-github.com/sauerbraten/fastprinter v0.0.0-20200109142611-26ce1e0b7924/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
+github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53 h1:sR+/8Yb4slttB4vD+b9btVEnWgL3Q00OBTzVT8B9C0c=
+github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=

--- a/node.go
+++ b/node.go
@@ -61,7 +61,7 @@ func (node *NodeBase) error(err error) {
 }
 
 func (node *NodeBase) errorf(format string, v ...interface{}) {
-	panic(fmt.Errorf("Jet Runtime Error(%q:%d): %s", node.TemplateName, node.Line, fmt.Sprintf(format, v...)))
+	panic(fmt.Errorf("jet runtime error @ %q:%d: %s", node.TemplateName, node.Line, fmt.Sprintf(format, v...)))
 }
 
 // Type returns itself and provides an easy default implementation

--- a/node.go
+++ b/node.go
@@ -61,7 +61,7 @@ func (node *NodeBase) error(err error) {
 }
 
 func (node *NodeBase) errorf(format string, v ...interface{}) {
-	panic(fmt.Errorf("jet runtime error @ %q:%d: %s", node.TemplateName, node.Line, fmt.Sprintf(format, v...)))
+	panic(fmt.Errorf("Jet Runtime Error (%q:%d): %s", node.TemplateName, node.Line, fmt.Sprintf(format, v...)))
 }
 
 // Type returns itself and provides an easy default implementation


### PR DESCRIPTION
Sorry for the big PR, but this was the easiest way to clean up the mess I created with the last PR :D

- make `Ranger` return `reflect.Values` again (see https://github.com/CloudyKit/jet/issues/122#issuecomment-572311118)
- fix #117 (using fix from https://github.com/CloudyKit/jet/issues/117#issuecomment-518576462)
- fix #122 (@tooolbox: check out https://github.com/sauerbraten/jet-example/tree/v2.1.3-6d666f94dfe7)
- fix #123 (@tooolbox: check out https://github.com/sauerbraten/jet-example/tree/v2.1.3-91ac9cb)
- move pointer dereferencing to fastprinter package (see https://github.com/CloudyKit/jet/pull/125#issuecomment-572555115, https://github.com/CloudyKit/fastprinter/pull/2)
- add `IsSet` function to `*Arguments` type

This PR obsoletes #125.