### PR TITLE
Clean up template loading

### DIFF
--- a/constructors.go
+++ b/constructors.go
@@ -21,133 +21,133 @@ import (
 )
 
 func (t *Template) newSliceExpr(pos Pos, line int, base, index, len Expression) *SliceExprNode {
-	return &SliceExprNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeSliceExpr, Pos: pos, Line: line}, Index: index, Base: base, EndIndex: len}
+	return &SliceExprNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeSliceExpr, Pos: pos, Line: line}, Index: index, Base: base, EndIndex: len}
 }
 
 func (t *Template) newIndexExpr(pos Pos, line int, base, index Expression) *IndexExprNode {
-	return &IndexExprNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeIndexExpr, Pos: pos, Line: line}, Index: index, Base: base}
+	return &IndexExprNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeIndexExpr, Pos: pos, Line: line}, Index: index, Base: base}
 }
 
 func (t *Template) newTernaryExpr(pos Pos, line int, boolean, left, right Expression) *TernaryExprNode {
-	return &TernaryExprNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeTernaryExpr, Pos: pos, Line: line}, Boolean: boolean, Left: left, Right: right}
+	return &TernaryExprNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeTernaryExpr, Pos: pos, Line: line}, Boolean: boolean, Left: left, Right: right}
 }
 
 func (t *Template) newSet(pos Pos, line int, isLet, isIndexExprGetLookup bool, left, right []Expression) *SetNode {
-	return &SetNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeSet, Pos: pos, Line: line}, Let: isLet, IndexExprGetLookup: isIndexExprGetLookup, Left: left, Right: right}
+	return &SetNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeSet, Pos: pos, Line: line}, Let: isLet, IndexExprGetLookup: isIndexExprGetLookup, Left: left, Right: right}
 }
 
 func (t *Template) newCallExpr(pos Pos, line int, expr Expression) *CallExprNode {
-	return &CallExprNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeCallExpr, Pos: pos, Line: line}, BaseExpr: expr}
+	return &CallExprNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeCallExpr, Pos: pos, Line: line}, BaseExpr: expr}
 }
 func (t *Template) newNotExpr(pos Pos, line int, expr Expression) *NotExprNode {
-	return &NotExprNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeNotExpr, Pos: pos, Line: line}, Expr: expr}
+	return &NotExprNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeNotExpr, Pos: pos, Line: line}, Expr: expr}
 }
 func (t *Template) newNumericComparativeExpr(pos Pos, line int, left, right Expression, item item) *NumericComparativeExprNode {
-	return &NumericComparativeExprNode{binaryExprNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeNumericComparativeExpr, Pos: pos, Line: line}, Operator: item, Left: left, Right: right}}
+	return &NumericComparativeExprNode{binaryExprNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeNumericComparativeExpr, Pos: pos, Line: line}, Operator: item, Left: left, Right: right}}
 }
 
 func (t *Template) newComparativeExpr(pos Pos, line int, left, right Expression, item item) *ComparativeExprNode {
-	return &ComparativeExprNode{binaryExprNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeComparativeExpr, Pos: pos, Line: line}, Operator: item, Left: left, Right: right}}
+	return &ComparativeExprNode{binaryExprNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeComparativeExpr, Pos: pos, Line: line}, Operator: item, Left: left, Right: right}}
 }
 
 func (t *Template) newLogicalExpr(pos Pos, line int, left, right Expression, item item) *LogicalExprNode {
-	return &LogicalExprNode{binaryExprNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeLogicalExpr, Pos: pos, Line: line}, Operator: item, Left: left, Right: right}}
+	return &LogicalExprNode{binaryExprNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeLogicalExpr, Pos: pos, Line: line}, Operator: item, Left: left, Right: right}}
 }
 
 func (t *Template) newMultiplicativeExpr(pos Pos, line int, left, right Expression, item item) *MultiplicativeExprNode {
-	return &MultiplicativeExprNode{binaryExprNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeMultiplicativeExpr, Pos: pos, Line: line}, Operator: item, Left: left, Right: right}}
+	return &MultiplicativeExprNode{binaryExprNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeMultiplicativeExpr, Pos: pos, Line: line}, Operator: item, Left: left, Right: right}}
 }
 
 func (t *Template) newAdditiveExpr(pos Pos, line int, left, right Expression, item item) *AdditiveExprNode {
-	return &AdditiveExprNode{binaryExprNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeAdditiveExpr, Pos: pos, Line: line}, Operator: item, Left: left, Right: right}}
+	return &AdditiveExprNode{binaryExprNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeAdditiveExpr, Pos: pos, Line: line}, Operator: item, Left: left, Right: right}}
 }
 
 func (t *Template) newList(pos Pos) *ListNode {
-	return &ListNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeList, Pos: pos}}
+	return &ListNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeList, Pos: pos}}
 }
 
 func (t *Template) newText(pos Pos, text string) *TextNode {
-	return &TextNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeText, Pos: pos}, Text: []byte(text)}
+	return &TextNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeText, Pos: pos}, Text: []byte(text)}
 }
 
 func (t *Template) newPipeline(pos Pos, line int) *PipeNode {
-	return &PipeNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodePipe, Pos: pos, Line: line}}
+	return &PipeNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodePipe, Pos: pos, Line: line}}
 }
 
 func (t *Template) newAction(pos Pos, line int) *ActionNode {
-	return &ActionNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeAction, Pos: pos, Line: line}}
+	return &ActionNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeAction, Pos: pos, Line: line}}
 }
 
 func (t *Template) newCommand(pos Pos) *CommandNode {
-	return &CommandNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeCommand, Pos: pos}}
+	return &CommandNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeCommand, Pos: pos}}
 }
 
 func (t *Template) newNil(pos Pos) *NilNode {
-	return &NilNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeNil, Pos: pos}}
+	return &NilNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeNil, Pos: pos}}
 }
 
 func (t *Template) newField(pos Pos, ident string) *FieldNode {
-	return &FieldNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeField, Pos: pos}, Ident: strings.Split(ident[1:], ".")} //[1:] to drop leading period
+	return &FieldNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeField, Pos: pos}, Ident: strings.Split(ident[1:], ".")} //[1:] to drop leading period
 }
 
 func (t *Template) newChain(pos Pos, node Node) *ChainNode {
-	return &ChainNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeChain, Pos: pos}, Node: node}
+	return &ChainNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeChain, Pos: pos}, Node: node}
 }
 
 func (t *Template) newBool(pos Pos, true bool) *BoolNode {
-	return &BoolNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeBool, Pos: pos}, True: true}
+	return &BoolNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeBool, Pos: pos}, True: true}
 }
 
 func (t *Template) newString(pos Pos, orig, text string) *StringNode {
-	return &StringNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeString, Pos: pos}, Quoted: orig, Text: text}
+	return &StringNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeString, Pos: pos}, Quoted: orig, Text: text}
 }
 
 func (t *Template) newEnd(pos Pos) *endNode {
-	return &endNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: nodeEnd, Pos: pos}}
+	return &endNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: nodeEnd, Pos: pos}}
 }
 
 func (t *Template) newContent(pos Pos) *contentNode {
-	return &contentNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: nodeContent, Pos: pos}}
+	return &contentNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: nodeContent, Pos: pos}}
 }
 
 func (t *Template) newElse(pos Pos, line int) *elseNode {
-	return &elseNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: nodeElse, Pos: pos, Line: line}}
+	return &elseNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: nodeElse, Pos: pos, Line: line}}
 }
 
 func (t *Template) newIf(pos Pos, line int, set *SetNode, pipe Expression, list, elseList *ListNode) *IfNode {
-	return &IfNode{BranchNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeIf, Pos: pos, Line: line}, Set: set, Expression: pipe, List: list, ElseList: elseList}}
+	return &IfNode{BranchNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeIf, Pos: pos, Line: line}, Set: set, Expression: pipe, List: list, ElseList: elseList}}
 }
 
 func (t *Template) newRange(pos Pos, line int, set *SetNode, pipe Expression, list, elseList *ListNode) *RangeNode {
-	return &RangeNode{BranchNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeRange, Pos: pos, Line: line}, Set: set, Expression: pipe, List: list, ElseList: elseList}}
+	return &RangeNode{BranchNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeRange, Pos: pos, Line: line}, Set: set, Expression: pipe, List: list, ElseList: elseList}}
 }
 
 func (t *Template) newBlock(pos Pos, line int, name string, parameters *BlockParameterList, pipe Expression, listNode, contentListNode *ListNode) *BlockNode {
-	return &BlockNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeBlock, Line: line, Pos: pos}, Name: name, Parameters: parameters, Expression: pipe, List: listNode, Content: contentListNode}
+	return &BlockNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeBlock, Line: line, Pos: pos}, Name: name, Parameters: parameters, Expression: pipe, List: listNode, Content: contentListNode}
 }
 
 func (t *Template) newYield(pos Pos, line int, name string, bplist *BlockParameterList, pipe Expression, content *ListNode, isContent bool) *YieldNode {
-	return &YieldNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeYield, Pos: pos, Line: line}, Name: name, Parameters: bplist, Expression: pipe, Content: content, IsContent: isContent}
+	return &YieldNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeYield, Pos: pos, Line: line}, Name: name, Parameters: bplist, Expression: pipe, Content: content, IsContent: isContent}
 }
 
 func (t *Template) newInclude(pos Pos, line int, name, context Expression) *IncludeNode {
-	return &IncludeNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeInclude, Pos: pos, Line: line}, Name: name, Context: context}
+	return &IncludeNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeInclude, Pos: pos, Line: line}, Name: name, Context: context}
 }
 
 func (t *Template) newReturn(pos Pos, line int, pipe Expression) *ReturnNode {
-	return &ReturnNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeReturn, Pos: pos, Line: line}, Value: pipe}
+	return &ReturnNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeReturn, Pos: pos, Line: line}, Value: pipe}
 }
 
 func (t *Template) newTry(pos Pos, line int, list *ListNode, catch *catchNode) *TryNode {
-	return &TryNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeTry, Pos: pos, Line: line}, List: list, Catch: catch}
+	return &TryNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeTry, Pos: pos, Line: line}, List: list, Catch: catch}
 }
 
 func (t *Template) newCatch(pos Pos, line int, errVar *IdentifierNode, list *ListNode) *catchNode {
-	return &catchNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: nodeCatch, Pos: pos, Line: line}, Err: errVar, List: list}
+	return &catchNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: nodeCatch, Pos: pos, Line: line}, Err: errVar, List: list}
 }
 
 func (t *Template) newNumber(pos Pos, text string, typ itemType) (*NumberNode, error) {
-	n := &NumberNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeNumber, Pos: pos}, Text: text}
+	n := &NumberNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeNumber, Pos: pos}, Text: text}
 	// todo: optimize
 	switch typ {
 	case itemCharConstant:
@@ -236,5 +236,5 @@ func (t *Template) newNumber(pos Pos, text string, typ itemType) (*NumberNode, e
 }
 
 func (t *Template) newIdentifier(ident string, pos Pos, line int) *IdentifierNode {
-	return &IdentifierNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeIdentifier, Pos: pos, Line: line}, Ident: ident}
+	return &IdentifierNode{NodeBase: NodeBase{TemplatePath: t.Name, NodeType: NodeIdentifier, Pos: pos, Line: line}, Ident: ident}
 }

--- a/default.go
+++ b/default.go
@@ -26,11 +26,7 @@ import (
 	"text/template"
 )
 
-var defaultExtensions = []string{
-	".html.jet",
-	".jet.html",
-	".jet",
-}
+
 
 var defaultVariables map[string]reflect.Value
 

--- a/eval.go
+++ b/eval.go
@@ -570,17 +570,17 @@ func (st *Runtime) executeTry(try *TryNode) (returnValue reflect.Value) {
 }
 
 func (st *Runtime) executeInclude(node *IncludeNode) (returnValue reflect.Value) {
-	var templateName string
+	var templatePath string
 	name := st.evalPrimaryExpressionGroup(node.Name)
 	if name.Type().Implements(stringerType) {
-		templateName = name.String()
+		templatePath = name.String()
 	} else if name.Kind() == reflect.String {
-		templateName = name.String()
+		templatePath = name.String()
 	} else {
 		node.errorf("evaluating name of template to include: unexpected expression type %q", getTypeString(name))
 	}
 
-	t, err := st.set.getTemplate(templateName, node.TemplateName)
+	t, err := st.set.getSiblingTemplate(templatePath, node.TemplatePath)
 	if err != nil {
 		node.error(err)
 		return reflect.Value{}

--- a/eval_test.go
+++ b/eval_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	JetTestingSet = NewSet(nil)
+	JetTestingSet = NewSet(nil, "")
 
 	ww    io.Writer = (*devNull)(nil)
 	users           = []*User{
@@ -560,7 +560,7 @@ func TestEvalBuiltinExpression(t *testing.T) {
 }
 
 func TestEvalAutoescape(t *testing.T) {
-	set := NewHTMLSet()
+	set := NewHTMLSet("")
 	RunJetTestWithSet(t, set, nil, nil, "Autoescapee_Test1", `<h1>{{"<h1>Hello Buddy!</h1>" }}</h1>`, "<h1>&lt;h1&gt;Hello Buddy!&lt;/h1&gt;</h1>")
 	RunJetTestWithSet(t, set, nil, nil, "Autoescapee_Test2", `<h1>{{"<h1>Hello Buddy!</h1>" |unsafe }}</h1>`, "<h1><h1>Hello Buddy!</h1></h1>")
 }

--- a/jettest/test.go
+++ b/jettest/test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // TestingSet holds a template set for running tests
-var TestingSet = jet.NewSet(nil)
+var TestingSet = jet.NewSet(nil, "")
 
 // Run runs jet template engine test, template will be loaded and cached in the default set TestingSet
 func Run(t *testing.T, variables jet.VarMap, context interface{}, testName, testContent, testExpected string) {

--- a/loader.go
+++ b/loader.go
@@ -15,81 +15,42 @@
 package jet
 
 import (
-	"errors"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 )
 
 // Loader is a minimal interface required for loading templates.
 type Loader interface {
+	// Exists checks for template existence.
+	Exists(path string) bool
 	// Open opens the underlying reader with template content.
-	Open(name string) (io.ReadCloser, error)
-	// Exists checks for template existence and returns full path.
-	Exists(name string) (string, bool)
-}
-
-// hasAddPath is an optional Loader interface. Most probably useful for OS file system only, thus unexported.
-type hasAddPath interface {
-	AddPath(path string)
-}
-
-// hasAddGopathPath is an optional Loader interface. Most probably useful for OS file system only, thus unexported.
-type hasAddGopathPath interface {
-	AddGopathPath(path string)
+	Open(path string) (io.ReadCloser, error)
 }
 
 // OSFileSystemLoader implements Loader interface using OS file system (os.File).
 type OSFileSystemLoader struct {
-	dirs []string
+	dir string
 }
 
+// compile time check that we implement Loader
+var _ Loader = (*OSFileSystemLoader)(nil)
+
 // NewOSFileSystemLoader returns an initialized OSFileSystemLoader.
-func NewOSFileSystemLoader(paths ...string) *OSFileSystemLoader {
-	return &OSFileSystemLoader{dirs: paths}
+func NewOSFileSystemLoader(dirPath string) *OSFileSystemLoader {
+	return &OSFileSystemLoader{
+		dir: dirPath,
+	}
 }
 
 // Open opens a file from OS file system.
-func (l *OSFileSystemLoader) Open(name string) (io.ReadCloser, error) {
-	return os.Open(name)
+func (l *OSFileSystemLoader) Open(path string) (io.ReadCloser, error) {
+	return os.Open(filepath.Join(l.dir, path))
 }
 
 // Exists checks if the template name exists by walking the list of template paths
-// returns string with the full path of the template and bool true if the template file was found
-func (l *OSFileSystemLoader) Exists(name string) (string, bool) {
-	for i := 0; i < len(l.dirs); i++ {
-		fileName := path.Join(l.dirs[i], name)
-		if _, err := os.Stat(fileName); err == nil {
-			return fileName, true
-		}
-	}
-	return "", false
-}
-
-// AddPath adds the path to the internal list of paths searched when loading templates.
-func (l *OSFileSystemLoader) AddPath(path string) {
-	l.dirs = append(l.dirs, path)
-}
-
-// AddGopathPath adds a path located in the GOPATH.
-// Example: l.AddGopathPath("github.com/CloudyKit/jet/example/views")
-func (l *OSFileSystemLoader) AddGopathPath(path string) {
-	paths := filepath.SplitList(os.Getenv("GOPATH"))
-	for i := 0; i < len(paths); i++ {
-		var err error
-		path, err = filepath.Abs(filepath.Join(paths[i], "src", path))
-		if err != nil {
-			panic(errors.New("Can't add this path err: " + err.Error()))
-		}
-
-		if fstats, err := os.Stat(path); os.IsNotExist(err) == false && fstats.IsDir() {
-			l.AddPath(path)
-			return
-		}
-	}
-
-	if fstats, err := os.Stat(path); os.IsNotExist(err) == false && fstats.IsDir() {
-		l.AddPath(path)
-	}
+// returns true if the template file was found
+func (l *OSFileSystemLoader) Exists(path string) bool {
+	stat, err := os.Stat(filepath.Join(l.dir, path))
+	return err == nil && !stat.IsDir()
 }

--- a/loader.go
+++ b/loader.go
@@ -23,7 +23,7 @@ import (
 // Loader is a minimal interface required for loading templates.
 type Loader interface {
 	// Exists checks for template existence.
-	Exists(path string) bool
+	Exists(path string) (string, bool)
 	// Open opens the underlying reader with template content.
 	Open(path string) (io.ReadCloser, error)
 }
@@ -50,7 +50,11 @@ func (l *OSFileSystemLoader) Open(path string) (io.ReadCloser, error) {
 
 // Exists checks if the template name exists by walking the list of template paths
 // returns true if the template file was found
-func (l *OSFileSystemLoader) Exists(path string) bool {
-	stat, err := os.Stat(filepath.Join(l.dir, path))
-	return err == nil && !stat.IsDir()
+func (l *OSFileSystemLoader) Exists(path string) (string, bool) {
+	path = filepath.Join(l.dir, path)
+	stat, err := os.Stat(path)
+	if err == nil && !stat.IsDir() {
+		return path, true
+	}
+	return "", false
 }

--- a/loaders/httpfs/httpfs_test.go
+++ b/loaders/httpfs/httpfs_test.go
@@ -9,12 +9,13 @@ import (
 )
 
 func TestNilHTTPFileSystem(t *testing.T) {
+	const fileName = "does-not-exists.jet"
 	l := NewLoader(nil)
-	if _, err := l.Open("does-not-exist.jet"); err == nil {
+	if _, err := l.Open(fileName); err == nil {
 		t.Fatal("Open should have returned an error but didn't.")
 	}
-	fileName, ok := l.Exists("does-not-exists.jet")
-	if fileName != "" || ok != false {
+	ok := l.Exists(fileName)
+	if ok {
 		t.Fatalf("Exists called on an empty file system should have returned empty and false but returned %q and %+v", fileName, ok)
 	}
 }

--- a/loaders/httpfs/httpfs_test.go
+++ b/loaders/httpfs/httpfs_test.go
@@ -14,9 +14,9 @@ func TestNilHTTPFileSystem(t *testing.T) {
 	if _, err := l.Open(fileName); err == nil {
 		t.Fatal("Open should have returned an error but didn't.")
 	}
-	ok := l.Exists(fileName)
+	actualName, ok := l.Exists(fileName)
 	if ok {
-		t.Fatalf("Exists called on an empty file system should have returned empty and false but returned %q and %+v", fileName, ok)
+		t.Fatalf("Exists called on an empty file system should have returned empty and false but said the template exists under the name %q", actualName)
 	}
 }
 

--- a/loaders/httpfs/loader.go
+++ b/loaders/httpfs/loader.go
@@ -27,13 +27,13 @@ func (l *httpFileSystemLoader) Open(name string) (io.ReadCloser, error) {
 
 // Exists checks if the template name exists by walking the list of template paths
 // returns string with the full path of the template and bool true if the template file was found
-func (l *httpFileSystemLoader) Exists(name string) (string, bool) {
+func (l *httpFileSystemLoader) Exists(name string) bool {
 	if l.fs == nil {
-		return "", false
+		return false
 	}
 	if f, err := l.Open(name); err == nil {
 		f.Close()
-		return name, true
+		return true
 	}
-	return "", false
+	return false
 }

--- a/loaders/httpfs/loader.go
+++ b/loaders/httpfs/loader.go
@@ -25,15 +25,15 @@ func (l *httpFileSystemLoader) Open(name string) (io.ReadCloser, error) {
 	return l.fs.Open(name)
 }
 
-// Exists checks if the template name exists by walking the list of template paths
+// Exists checks if the template with the given name exists by walking the list of template paths
 // returns string with the full path of the template and bool true if the template file was found
-func (l *httpFileSystemLoader) Exists(name string) bool {
+func (l *httpFileSystemLoader) Exists(name string) (string, bool) {
 	if l.fs == nil {
-		return false
+		return "", false
 	}
 	if f, err := l.Open(name); err == nil {
 		f.Close()
-		return true
+		return name, true
 	}
-	return false
+	return "", false
 }

--- a/loaders/multi/multi.go
+++ b/loaders/multi/multi.go
@@ -8,6 +8,8 @@ import (
 )
 
 // Multi implements jet.Loader interface and tries to load templates from a list of custom loaders.
+// Caution: When multiple loaders have templates with the same name, the order in which you pass loaders
+// to NewLoader/AddLoaders dictates which template will be returned by Open when you request it!
 type Multi struct {
 	loaders []jet.Loader
 }
@@ -40,11 +42,11 @@ func (m *Multi) Open(name string) (io.ReadCloser, error) {
 
 // Exists checks all loaders in succession, returning the full path of the template and
 // bool true if the template file was found, otherwise it returns an empty string and false.
-func (m *Multi) Exists(name string) (string, bool) {
+func (m *Multi) Exists(name string) bool {
 	for _, loader := range m.loaders {
-		if fileName, ok := loader.Exists(name); ok {
-			return fileName, true
+		if ok := loader.Exists(name); ok {
+			return true
 		}
 	}
-	return "", false
+	return false
 }

--- a/loaders/multi/multi.go
+++ b/loaders/multi/multi.go
@@ -42,11 +42,11 @@ func (m *Multi) Open(name string) (io.ReadCloser, error) {
 
 // Exists checks all loaders in succession, returning the full path of the template and
 // bool true if the template file was found, otherwise it returns an empty string and false.
-func (m *Multi) Exists(name string) bool {
+func (m *Multi) Exists(name string) (string, bool) {
 	for _, loader := range m.loaders {
-		if ok := loader.Exists(name); ok {
-			return true
+		if name, ok := loader.Exists(name); ok {
+			return name, true
 		}
 	}
-	return false
+	return "", false
 }

--- a/loaders/multi/multi_test.go
+++ b/loaders/multi/multi_test.go
@@ -10,12 +10,13 @@ import (
 )
 
 func TestZeroLoaders(t *testing.T) {
+	const fileName = "does-not-exists.jet"
 	l := NewLoader()
 	if _, err := l.Open("does-not-exist.jet"); err == nil {
 		t.Fatal("Open should have returned an error but didn't.")
 	}
-	fileName, ok := l.Exists("does-not-exists.jet")
-	if fileName != "" || ok != false {
+	ok := l.Exists(fileName)
+	if ok {
 		t.Fatalf("Exists called on an empty file system should have returned empty and false but returned %q and %+v", fileName, ok)
 	}
 }

--- a/loaders/multi/multi_test.go
+++ b/loaders/multi/multi_test.go
@@ -15,9 +15,9 @@ func TestZeroLoaders(t *testing.T) {
 	if _, err := l.Open("does-not-exist.jet"); err == nil {
 		t.Fatal("Open should have returned an error but didn't.")
 	}
-	ok := l.Exists(fileName)
+	fullPath, ok := l.Exists(fileName)
 	if ok {
-		t.Fatalf("Exists called on an empty file system should have returned empty and false but returned %q and %+v", fileName, ok)
+		t.Fatalf("Exists called on an empty file system should have returned empty and false but reported the template exists under the full path %q", fullPath)
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -46,7 +46,7 @@ func (p Pos) Position() Pos {
 type NodeType int
 
 type NodeBase struct {
-	TemplateName string
+	TemplatePath string
 	Line         int
 	NodeType
 	Pos
@@ -61,7 +61,7 @@ func (node *NodeBase) error(err error) {
 }
 
 func (node *NodeBase) errorf(format string, v ...interface{}) {
-	panic(fmt.Errorf("Jet Runtime Error (%q:%d): %s", node.TemplateName, node.Line, fmt.Sprintf(format, v...)))
+	panic(fmt.Errorf("Jet Runtime Error (%q:%d): %s", node.TemplatePath, node.Line, fmt.Sprintf(format, v...)))
 }
 
 // Type returns itself and provides an easy default implementation

--- a/template.go
+++ b/template.go
@@ -126,7 +126,7 @@ func (s *Set) getTemplateFromLoader(path string) (t *Template, err error) {
 	// check path with all possible extensions in loader
 	for _, extension := range s.extensions {
 		canonicalPath := path + extension
-		if found := s.loader.Exists(canonicalPath); found {
+		if _, found := s.loader.Exists(canonicalPath); found {
 			return s.loadFromFile(canonicalPath)
 		}
 	}

--- a/utils/visitor_test.go
+++ b/utils/visitor_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/CloudyKit/jet/v3"
 )
 
-var Set = jet.NewHTMLSet()
+var Set = jet.NewHTMLSet("")
 
 func TestVisitor(t *testing.T) {
 	var collectedIdentifiers []string


### PR DESCRIPTION
This fixes #127 (paths in templates will be handled as described there) and #128.

Breaking changes:

- `OSFileSystemLoader` only supports a single directory instead of multiple
- the `AddPath` and `AddGopathPath` functions were removed
- ~~`Loader.Exists` no longer returns the "real" file name~~
- after `include` or `extends`, relative paths will no longer be looked up as absolute paths (see #127)

I removed the ability to have multiple directories managed by a single `OSFileSystemLoader` becaue of #128, and because I feel like
1. most users will have all templates in a single directory, organized into subdirectories there,
2. with the new handling of relative paths, the top directory name will appear in paths less often, and
3. you can always use `loaders.Multi` to get back the functionality a single `OSFileSystemLoader` provided before

I added a note to `loaders.Multi` warning that lookup order depends on the order in which loaders are passed in during instantiation.