### PR TITLE
Don't panic when parameter name in yield is missing

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -319,6 +319,11 @@ func (st *Runtime) executeYieldBlock(block *BlockNode, blockParam, yieldParam *B
 		st.newScope()
 		for i := 0; i < len(yieldParam.List); i++ {
 			p := &yieldParam.List[i]
+			
+			if p.Expression == nil {
+				block.errorf("missing name for block parameter '%s'", blockParam.List[i].Identifier)
+			}
+
 			st.variables[p.Identifier] = st.evalPrimaryExpressionGroup(p.Expression)
 		}
 		for i := 0; i < len(blockParam.List); i++ {


### PR DESCRIPTION
Previously, when Jet encountered a `yield` statement that's missing a parameter name like `{{yield foo(p)}}` it would panic because of a null pointer. This change will detect the missing name and throw an error instead.

Closes #133 