### PR TITLE
fix fallthrough bug in getRanger 

### DIFF
--- a/default.go
+++ b/default.go
@@ -77,7 +77,7 @@ func init() {
 				return reflect.ValueOf(expression.NumField())
 			}
 
-			a.Panicf("inválid value type %s in len builtin", expression.Type())
+			a.Panicf("invalid value type %s in len builtin", expression.Type())
 			return reflect.Value{}
 		})),
 		"includeIfExists": reflect.ValueOf(Func(func(a Arguments) reflect.Value {

--- a/eval.go
+++ b/eval.go
@@ -321,7 +321,7 @@ func (st *Runtime) executeYieldBlock(block *BlockNode, blockParam, yieldParam *B
 		st.newScope()
 		for i := 0; i < len(yieldParam.List); i++ {
 			p := &yieldParam.List[i]
-			
+
 			if p.Expression == nil {
 				block.errorf("missing name for block parameter '%s'", blockParam.List[i].Identifier)
 			}
@@ -1520,16 +1520,16 @@ func buildCache(typ reflect.Type, cache map[string][]int, parent []int) {
 }
 
 func getRanger(v reflect.Value) Ranger {
-	tuP := v.Type()
-	if tuP.Implements(rangerType) {
+	t := v.Type()
+	if t.Implements(rangerType) {
 		return v.Interface().(Ranger)
 	}
-	k := tuP.Kind()
+	v, isNil := indirect(v)
+	if isNil {
+		panic(fmt.Errorf("cannot range over nil pointer/interface (%s)", t))
+	}
+	k := v.Kind()
 	switch k {
-	case reflect.Ptr, reflect.Interface:
-		v = v.Elem()
-		k = v.Kind()
-		fallthrough
 	case reflect.Slice, reflect.Array:
 		sliceranger := pool_sliceRanger.Get().(*sliceRanger)
 		sliceranger.i = -1
@@ -1545,7 +1545,7 @@ func getRanger(v reflect.Value) Ranger {
 		*chanranger = chanRanger{v: v}
 		return chanranger
 	}
-	panic(fmt.Errorf("type %s is not rangeable", tuP))
+	panic(fmt.Errorf("value %v (type %s) is not rangeable", v, t))
 }
 
 var (


### PR DESCRIPTION
A pointer (or interface value that does not implement the Ranger type) would be treated like a slice or array, regardless of the underlying value's kind.

`fallthrough` jumps to the next case block without verifying the case condition, which is not what we want in the case of indirection.