### PR TITLE
recover from panics that happen when evaluating an expression inside isset()

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -650,7 +650,14 @@ func notNil(v reflect.Value) bool {
 	}
 }
 
-func (st *Runtime) isSet(node Node) bool {
+func (st *Runtime) isSet(node Node) (ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			// something panicked while evaluating node
+			ok = false
+		}
+	}()
+
 	nodeType := node.Type()
 
 	switch nodeType {

--- a/eval_test.go
+++ b/eval_test.go
@@ -553,6 +553,10 @@ func TestEvalBuiltinExpression(t *testing.T) {
 	RunJetTest(t, data, nil, "IsSetExpression_11", `{{isset(foo.bar)}}`, "false")
 	RunJetTest(t, data, nil, "IsSetExpression_12", `{{isset(foo.asd.foo)}}`, "false")
 	RunJetTest(t, data, nil, "IsSetExpression_13", `{{isset(foo.asd.bar.xyz)}}`, "false")
+	data.Set(
+		"foo", map[string]interface{}{},
+	)
+	RunJetTest(t, data, nil, "IsSetExpression_14", `{{isset(foo.asd[0].bar)}}`, "false")
 }
 
 func TestEvalAutoescape(t *testing.T) {


### PR DESCRIPTION
Previously, code like
```
{{ bla := map() }}
{{ if isset(bla.foo[0].bar)}}
    true
{{else}}
    false
{{end}}
```
would produce a panic, because `bla.foo[0].bar` is parsed as a chain node consisting of `bla.foo[0]` as base and `.bar` as the single field. evalChainNodeExpression() then evaluated `bla.foo[0]` as an index expression using evalPrimaryExpressionGroup(), which would result in a panic.

This change recovers from all panics happening during the evaluation of the argument to isset().

(The duplication of logic between isSet() and evalPrimaryExpressionGroup() is a continued source of bugs and inconsitencies and I'd like to try and get rid of it in the long term by making isSet() a simple wrapper around evalPrimaryExpressionGroup() with the recover code from this change.)