### PR TITLE
Assign the range key/index in one-var syntax with rangers that provide an index

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1500,9 +1500,10 @@ func resolveIndex(v, index reflect.Value) (reflect.Value, error) {
 		return reflect.Value{}, fmt.Errorf("can't use %s as field name in struct type %s", index, v.Type())
 	case reflect.Map:
 		// If it's a map, attempt to use the field name as a key.
-		if !index.Type().AssignableTo(v.Type().Key()) {
+		if !index.Type().ConvertibleTo(v.Type().Key()) {
 			return reflect.Value{}, fmt.Errorf("can't use %s (%s) as key for map of type %s", index, index.Type(), v.Type())
 		}
+		index = index.Convert(v.Type().Key()) // noop in most cases, but not expensive
 		return indirectEface(v.MapIndex(index)), nil
 	case reflect.Ptr:
 		etyp := v.Type().Elem()

--- a/eval_test.go
+++ b/eval_test.go
@@ -289,7 +289,7 @@ func TestEvalRangeNode(t *testing.T) {
 
 	const resultString = `<h1>Mario Santos<small>mario@gmail.com</small></h1><h1>Joel Silva<small>joelsilva@gmail.com</small></h1><h1>Luis Santana<small>luis.santana@gmail.com</small></h1>`
 	RunJetTest(t, data, nil, "Range_Expression", `{{range users}}<h1>{{.Name}}<small>{{.Email}}</small></h1>{{end}}`, resultString)
-	RunJetTest(t, data, nil, "Range_ExpressionValue", `{{range user:=users}}<h1>{{user.Name}}<small>{{user.Email}}</small></h1>{{end}}`, resultString)
+	RunJetTest(t, data, nil, "Range_ExpressionValue", `{{range _,user:=users}}<h1>{{user.Name}}<small>{{user.Email}}</small></h1>{{end}}`, resultString)
 	var resultString2 = `<h1>0: Mario Santos<small>mario@gmail.com</small></h1><h1>Joel Silva<small>joelsilva@gmail.com</small></h1><h1>2: Luis Santana<small>luis.santana@gmail.com</small></h1>`
 	RunJetTest(t, data, nil, "Range_ExpressionValueIf", `{{range i, user:=users}}<h1>{{if i == 0 || i == 2}}{{i}}: {{end}}{{user.Name}}<small>{{user.Email}}</small></h1>{{end}}`, resultString2)
 }
@@ -661,15 +661,20 @@ func TestRanger(t *testing.T) {
 	var data = make(VarMap)
 	data.Set(
 		"m", map[string]interface{}{
-			"asd": 1,
+			"asd": 123,
 			//"foo": "blub", // adding more values here means we can't predict the order below
 			//"bar": nil,
 		},
 	)
 	data.Set("s", []string{"asd", "foo", "bar"})
 	data.Set("c", c)
-	RunJetTest(t, data, nil, "slice_ranger", `{{ range i, v := s }}{{i}}:{{v}},{{ end }}`, "0:asd,1:foo,2:bar,")
-	RunJetTest(t, data, nil, "map_ranger", `{{ range k, v := m }}{{k}}:{{v}},{{ end }}`, "asd:1,")
+	RunJetTest(t, data, nil, "slice_ranger", `{{ range s }}{{.}},{{ end }}`, "asd,foo,bar,")
+	RunJetTest(t, data, nil, "slice_ranger_value", `{{ range v := s }}{{v}},{{ end }}`, "0,1,2,")
+	RunJetTest(t, data, nil, "slice_ranger_value_context", `{{ range v := s }}{{.}},{{ end }}`, "asd,foo,bar,")
+	RunJetTest(t, data, nil, "slice_ranger_index_value", `{{ range i, v := s }}{{i}}:{{v}},{{ end }}`, "0:asd,1:foo,2:bar,")
+	RunJetTest(t, data, nil, "map_ranger", `{{ range m }}{{.}},{{ end }}`, "123,")
+	RunJetTest(t, data, nil, "map_ranger_key_context", `{{ range k := m }}{{k}}:{{.}},{{ end }}`, "asd:123,")
+	RunJetTest(t, data, nil, "map_ranger_key_value", `{{ range k, v := m }}{{k}}:{{v}},{{ end }}`, "asd:123,")
 	RunJetTest(t, data, nil, "chan_ranger", `{{ range v := c }}{{v}}{{ end }}`, "0123456789")
 	RunJetTest(t, nil, nil, "ints_ranger", `{{ range i := ints(0, 10) }}{{ (i == 0 ? "" : ", ") + i }}{{ end }}`, "0, 1, 2, 3, 4, 5, 6, 7, 8, 9")
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -643,6 +643,14 @@ func TestTryCatch(t *testing.T) {
 	RunJetTestWithSet(t, set, nil, nil, "try_include", "", "before broken include ...\n\nafter broken include ...")
 }
 
+func TestBuiltinCollectionFuncs(t *testing.T) {
+	RunJetTest(t, nil, nil, "map_builtin", `{{ m := map( "foo", "bar", "asd", 123)}}{{m}}`, "map[asd:123 foo:bar]")
+	RunJetTest(t, nil, nil, "map_builtin_odd_args", `{{ m := map( "foo", "bar", 123, "asd")}}{{m}}`, "map[asd:123 foo:bar]")
+	RunJetTest(t, nil, nil, "slice_builtin", `{{ m := slice( "foo", "bar", "asd", 123)}}{{m}}`, "[foo bar asd 123]")
+	RunJetTest(t, nil, nil, "slice_builtin_subslice", `{{ m := slice( "foo", "bar", "asd", 123)}}{{m[1:3]}}`, "[bar asd]")
+	RunJetTest(t, nil, nil, "array_builtin", `{{ m := array( "foo", "bar", "asd", 123)}}{{m}}`, "[foo bar asd 123]")
+}
+
 func TestRanger(t *testing.T) {
 	c := make(chan string)
 	go func() {

--- a/eval_test.go
+++ b/eval_test.go
@@ -645,7 +645,6 @@ func TestTryCatch(t *testing.T) {
 
 func TestBuiltinCollectionFuncs(t *testing.T) {
 	RunJetTest(t, nil, nil, "map_builtin", `{{ m := map( "foo", "bar", "asd", 123)}}{{m}}`, "map[asd:123 foo:bar]")
-	RunJetTest(t, nil, nil, "map_builtin_odd_args", `{{ m := map( "foo", "bar", 123, "asd")}}{{m}}`, "map[asd:123 foo:bar]")
 	RunJetTest(t, nil, nil, "slice_builtin", `{{ m := slice( "foo", "bar", "asd", 123)}}{{m}}`, "[foo bar asd 123]")
 	RunJetTest(t, nil, nil, "slice_builtin_subslice", `{{ m := slice( "foo", "bar", "asd", 123)}}{{m[1:3]}}`, "[bar asd]")
 	RunJetTest(t, nil, nil, "array_builtin", `{{ m := array( "foo", "bar", "asd", 123)}}{{m}}`, "[foo bar asd 123]")


### PR DESCRIPTION
Basically, if the ranger provides both a range value and index, the one-var syntax sets that var to the index. If the ranger provides no index, one-var syntax will give you the value.

This way, Jet's range now behaves like Go's range for maps, slices, arrays, and channels.

Closes #158.