### PR TITLE
Add ProvidesIndex() bool to complete the new jet.Ranger interface

### DIFF
--- a/examples/todos/main.go
+++ b/examples/todos/main.go
@@ -64,6 +64,8 @@ func (dt *doneTODOs) Range() (reflect.Value, reflect.Value, bool) {
 	return reflect.Value{}, reflect.Value{}, true
 }
 
+func (dt *doneTODOs) ProvidesIndex() bool { return true }
+
 // Render implements jet.Renderer interface
 func (t *tTODO) Render(r *jet.Runtime) {
 	done := "yes"


### PR DESCRIPTION
`todos` example: Add `ProvidesIndex() bool` method to `doneTODOs` in order to complete the new `jet.Ranger` interface, which now contains two methods, the `Range` and the new `ProvidesIndex`.

/ping @razonyang 