### PR TITLE
cache more aggressively; remove Set.LoadTemplate()

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -606,7 +606,7 @@ func (st *Runtime) executeInclude(node *IncludeNode) (returnValue reflect.Value)
 	}
 
 	st.set.tmx.RLock()
-	t, err := st.set.getSiblingTemplate(templatePath, node.TemplatePath)
+	t, err := st.set.getSiblingTemplate(templatePath, node.TemplatePath, true)
 	st.set.tmx.RUnlock()
 	if err != nil {
 		node.error(err)

--- a/jettest/test.go
+++ b/jettest/test.go
@@ -23,36 +23,15 @@ import (
 	"github.com/CloudyKit/jet/v5"
 )
 
-// TestingSet holds a template set for running tests
-var TestingSet = jet.NewSet(nil, "")
-
-// Run runs jet template engine test, template will be loaded and cached in the default set TestingSet
-func Run(t *testing.T, variables jet.VarMap, context interface{}, testName, testContent, testExpected string) {
-	RunWithSet(t, TestingSet, variables, context, testName, testContent, testExpected)
-}
-
-// RunWithSet like Run but accepts a jet.Set as a parameter to be used instead of the default set
-func RunWithSet(t *testing.T, set *jet.Set, variables jet.VarMap, context interface{}, testName, testContent, testExpected string) {
-	var (
-		tt  *jet.Template
-		err error
-	)
-
-	if testContent != "" {
-		tt, err = set.LoadTemplate(testName, testContent)
-	} else {
-		tt, err = set.GetTemplate(testName)
-	}
-
+func RunWithSet(t *testing.T, set *jet.Set, variables jet.VarMap, context interface{}, testName, testExpected string) {
+	tt, err := set.GetTemplate(testName)
 	if err != nil {
-		t.Errorf("Parsing error: %s %s %s", err.Error(), testName, testContent)
+		t.Errorf("Error parsing templates for test %s: %v", testName, err)
 		return
 	}
-
 	RunWithTemplate(t, tt, variables, context, testExpected)
 }
 
-// RunWithTemplate like Run but accepts a jet.Template
 func RunWithTemplate(t *testing.T, tt *jet.Template, variables jet.VarMap, context interface{}, testExpected string) {
 	if testing.RunTests(func(pat, str string) (bool, error) {
 		return true, nil

--- a/loaders/httpfs/httpfs_test.go
+++ b/loaders/httpfs/httpfs_test.go
@@ -23,8 +23,8 @@ func TestNilHTTPFileSystem(t *testing.T) {
 func TestHTTPFileSystemResolve(t *testing.T) {
 	fs := http.Dir("testData/includeIfNotExists")
 	set := jet.NewHTMLSetLoader(NewLoader(fs))
-	jettest.RunWithSet(t, set, nil, nil, "existent", "", "Hi, i exist!!")
-	jettest.RunWithSet(t, set, nil, nil, "notExistent", "", "")
-	jettest.RunWithSet(t, set, nil, nil, "ifIncludeIfExits", "", "Hi, i exist!!\n    Was included!!\n\n\n    Was not included!!\n\n")
-	jettest.RunWithSet(t, set, nil, "World", "wcontext", "", "Hi, Buddy!\nHi, World!")
+	jettest.RunWithSet(t, set, nil, nil, "existent", "Hi, i exist!!")
+	jettest.RunWithSet(t, set, nil, nil, "notExistent", "")
+	jettest.RunWithSet(t, set, nil, nil, "ifIncludeIfExits", "Hi, i exist!!\n    Was included!!\n\n\n    Was not included!!\n\n")
+	jettest.RunWithSet(t, set, nil, "World", "wcontext", "Hi, Buddy!\nHi, World!")
 }

--- a/loaders/multi/multi_test.go
+++ b/loaders/multi/multi_test.go
@@ -26,7 +26,7 @@ func TestTwoLoaders(t *testing.T) {
 	httpFSLoader := httpfs.NewLoader(http.Dir("../../testData"))
 	l := NewLoader(osFSLoader, httpFSLoader)
 	set := jet.NewHTMLSetLoader(l)
-	jettest.RunWithSet(t, set, nil, nil, "resolve/simple.jet", "", "simple.jet")
-	jettest.RunWithSet(t, set, nil, nil, "base.jet", "", "")
-	jettest.RunWithSet(t, set, nil, nil, "simple2", "", "simple2\n")
+	jettest.RunWithSet(t, set, nil, nil, "resolve/simple.jet", "simple.jet")
+	jettest.RunWithSet(t, set, nil, nil, "base.jet", "")
+	jettest.RunWithSet(t, set, nil, nil, "simple2", "simple2\n")
 }

--- a/node.go
+++ b/node.go
@@ -17,6 +17,7 @@ package jet
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 )
 
 var textFormat = "%s" //Changed to "%q" in tests for better error messages.
@@ -61,7 +62,7 @@ func (node *NodeBase) error(err error) {
 }
 
 func (node *NodeBase) errorf(format string, v ...interface{}) {
-	panic(fmt.Errorf("Jet Runtime Error (%q:%d): %s", node.TemplatePath, node.Line, fmt.Sprintf(format, v...)))
+	panic(fmt.Errorf("Jet Runtime Error (%q:%d): %s", filepath.ToSlash(node.TemplatePath), node.Line, fmt.Sprintf(format, v...)))
 }
 
 // Type returns itself and provides an easy default implementation

--- a/parse.go
+++ b/parse.go
@@ -174,7 +174,7 @@ func (t *Template) recover(errp *error) {
 	return
 }
 
-func (s *Set) parse(name, text string) (t *Template, err error) {
+func (s *Set) parse(name, text string, cacheAfterParsing bool) (t *Template, err error) {
 	t = &Template{
 		Name:         name,
 		ParseName:    name,
@@ -188,7 +188,7 @@ func (s *Set) parse(name, text string) (t *Template, err error) {
 	lexer.setDelimiters(s.leftDelim, s.rightDelim)
 	lexer.run()
 	t.startParse(lexer)
-	t.parseTemplate()
+	t.parseTemplate(cacheAfterParsing)
 	t.stopParse()
 
 	if t.extends != nil {
@@ -215,7 +215,7 @@ func (t *Template) expectString(context string) string {
 
 // parse is the top-level parser for a template, essentially the same
 // It runs to EOF.
-func (t *Template) parseTemplate() (next Node) {
+func (t *Template) parseTemplate(cacheAfterParsing bool) (next Node) {
 	t.Root = t.newList(t.peek().pos)
 	// {{ extends|import stringLiteral }}
 	for t.peek().typ != itemEOF {
@@ -234,12 +234,12 @@ func (t *Template) parseTemplate() (next Node) {
 						t.errorf("Unexpected extends clause: the 'extends' clause should come before all import clauses")
 					}
 					var err error
-					t.extends, err = t.set.getSiblingTemplate(s, t.Name)
+					t.extends, err = t.set.getSiblingTemplate(s, t.Name, cacheAfterParsing)
 					if err != nil {
 						t.error(err)
 					}
 				} else {
-					tt, err := t.set.getSiblingTemplate(s, t.Name)
+					tt, err := t.set.getSiblingTemplate(s, t.Name, cacheAfterParsing)
 					if err != nil {
 						t.error(err)
 					}

--- a/parse_test.go
+++ b/parse_test.go
@@ -34,7 +34,7 @@ func (t ParserTestCase) ExpectPrintName(name, input, output string) {
 	if t.set != nil {
 		set = t.set
 	}
-	template, err := set.parse(name, input)
+	template, err := set.parse(name, input, false)
 	if err != nil {
 		t.Errorf("%q %s", input, err.Error())
 		return
@@ -55,7 +55,7 @@ func (t ParserTestCase) ExpectError(name, input, errorMessage string) {
 	if t.set != nil {
 		set = t.set
 	}
-	_, err := set.parse(name, input)
+	_, err := set.parse(name, input, false)
 	if err == nil {
 		t.Errorf("expected %q but got no error", errorMessage)
 		return

--- a/template_test.go
+++ b/template_test.go
@@ -34,3 +34,27 @@ func TestSetSetExtensions(t *testing.T) {
 		}
 	}
 }
+
+func TestParseDoesNotCache(t *testing.T) {
+	loader := NewInMemLoader()
+	set := NewHTMLSetLoader(loader)
+	_, err := set.Parse("/asd.jet", `{{ foo := "bar" }}{{foo}}`)
+	if err != nil {
+		t.Errorf("parsing template: %v", err)
+		return
+	}
+	if len(set.templates) > 0 {
+		t.Errorf("template is cached in set after Parse()")
+	}
+
+	loader.Set("/something_to_extend.jet", "some content to extend")
+
+	_, err = set.Parse("/includes_template.jet", `{{ extends "/something_to_extend.jet" }}, and more content`)
+	if err != nil {
+		t.Errorf("parsing template: %v", err)
+		return
+	}
+	if len(set.templates) > 0 {
+		t.Errorf("one or more template(s) are cached in set after Parse()")
+	}
+}

--- a/utils/visitor_test.go
+++ b/utils/visitor_test.go
@@ -3,15 +3,20 @@ package utils
 import (
 	"reflect"
 	"testing"
+	"text/template"
 
 	"github.com/CloudyKit/jet/v5"
 )
 
-var Set = jet.NewHTMLSet("")
+var (
+	Loader = jet.NewInMemLoader()
+	Set    = jet.NewSetLoader(template.HTMLEscape, Loader)
+)
 
 func TestVisitor(t *testing.T) {
 	var collectedIdentifiers []string
-	var mTemplate, _ = Set.LoadTemplate("_testing", "{{ ident1 }}\n{{ ident2(ident3)}}\n{{ if ident4 }}\n    {{ident5}}\n{{else}}\n    {{ident6}}\n{{end}}\n{{ ident7|ident8|ident9+ident10|ident11[ident12]: ident13[ident14:ident15] }}")
+	Loader.Set("_testing", "{{ ident1 }}\n{{ ident2(ident3)}}\n{{ if ident4 }}\n    {{ident5}}\n{{else}}\n    {{ident6}}\n{{end}}\n{{ ident7|ident8|ident9+ident10|ident11[ident12]: ident13[ident14:ident15] }}")
+	mTemplate, _ := Set.GetTemplate("_testing")
 	Walk(mTemplate, VisitorFunc(func(context VisitorContext, node jet.Node) {
 		if node.Type() == jet.NodeIdentifier {
 			collectedIdentifiers = append(collectedIdentifiers, node.String())
@@ -24,7 +29,8 @@ func TestVisitor(t *testing.T) {
 }
 
 func TestSimpleTemplate(t *testing.T) {
-	var mTemplate, err = Set.LoadTemplate("_testing2", "<html><head><title>Thank you!</title></head>\n\n<body>\n\tHello {{userName}},\n\n\tThanks for the order!\n\n\t{{range product := products}}\n\t\t{{product.name}}\n\n\t    {{block productPrice(price=product.Price) product}}\n            {{if price > ExpensiveProduct}}\n                Expensive!!\n            {{end}}\n        {{end}}\n\n\t\t${{product.price / 100}}\n\t{{end}}\n</body>\n</html>")
+	Loader.Set("_testing2", "<html><head><title>Thank you!</title></head>\n\n<body>\n\tHello {{userName}},\n\n\tThanks for the order!\n\n\t{{range product := products}}\n\t\t{{product.name}}\n\n\t    {{block productPrice(price=product.Price) product}}\n            {{if price > ExpensiveProduct}}\n                Expensive!!\n            {{end}}\n        {{end}}\n\n\t\t${{product.price / 100}}\n\t{{end}}\n</body>\n</html>")
+	mTemplate, err := Set.GetTemplate("_testing2")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
~~Keeping track of wether or not to cache templates that are imported/extended during Parse() is too much work, so Parse() is gone for now.~~ LoadTemplate() is removed in favor of a new in-memory Loader where you can add templates on-the-fly (which is also used for tests without template files). Using it together with a file loader via a multi loader restores the previous functionality.

I believe this fixes #180.