### PR TITLE
Custom resolvers

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -70,13 +70,39 @@ func (w *escapeeWriter) Write(b []byte) (int, error) {
 	return 0, nil
 }
 
+// Resolver resolves identifiers to variables, context, and functions.
+type Resolver interface {
+	Resolve(name string) (reflect.Value, error)
+}
+
+// defaultResolver wraps and delegates to Runtime, fulfilling the Resolver interface.
+//
+// Runtime declares the resolve function which checks context, variables, globals,
+// and default variables.
+type defaultResolver struct {
+	*Runtime
+}
+
+func (r *defaultResolver) Resolve(name string) (reflect.Value, error) {
+	return r.Runtime.resolve(name)
+}
+
 // Runtime this type holds the state of the execution of an template
 type Runtime struct {
 	*escapeeWriter
 	*scope
 	content func(*Runtime, Expression)
-
 	context reflect.Value
+
+	// customResolver represents a custom Resolver used to interpret and evaluate
+	// templates.
+	customResolver Resolver
+}
+
+// DefaultResolver returns the default resolver for Jet, which checks
+// the context, variables, globals, and default variables in that order.
+func (r *Runtime) DefaultResolver() Resolver {
+	return &defaultResolver{Runtime: r}
 }
 
 // Context returns the current context value
@@ -139,6 +165,11 @@ func (state *Runtime) setValue(name string, val reflect.Value) error {
 	return fmt.Errorf("could not assign %q = %v because variable %q is uninitialised", name, val, name)
 }
 
+// WithResolver sets a custom resolver for use within this runtime.
+func (state *Runtime) WithResolver(r Resolver) {
+	state.customResolver = r
+}
+
 // LetGlobal sets or initialises a variable in the top-most template scope.
 func (state *Runtime) LetGlobal(name string, val interface{}) {
 	sc := state.scope
@@ -171,8 +202,17 @@ func (state *Runtime) SetOrLet(name string, val interface{}) {
 	}
 }
 
-// Resolve resolves a value from the execution context.
+// resolve resolves a value from the execution context using the custom resolver
+// if provided.
 func (state *Runtime) resolve(name string) (reflect.Value, error) {
+	if state.customResolver == nil {
+		return state.defaultResolve(name)
+	}
+	return state.customResolver.Resolve(name)
+}
+
+// defaultResolve resolves a value from the execution context.
+func (state *Runtime) defaultResolve(name string) (reflect.Value, error) {
 	if name == "." {
 		return state.context, nil
 	}
@@ -223,6 +263,7 @@ func (st *Runtime) recover(err *error) {
 	// reset state scope and context just to be safe (they might not be cleared properly if there was a panic while using the state)
 	st.scope = &scope{}
 	st.context = reflect.Value{}
+	st.customResolver = nil
 	pool_State.Put(st)
 	if recovered := recover(); recovered != nil {
 		var ok bool

--- a/exec.go
+++ b/exec.go
@@ -40,9 +40,12 @@ func (scope VarMap) SetWriter(name string, v SafeWriter) VarMap {
 	return scope
 }
 
-func (t *Template) ExecuteWith(r Resolver, w io.Writer, variables VarMap, data interface{}) (err error) {
+func (t *Template) Runtime() *Runtime {
 	st := pool_State.Get().(*Runtime)
-	st.WithResolver(r)
+	return st
+}
+
+func (t *Template) ExecuteWith(st *Runtime, w io.Writer, variables VarMap, data interface{}) (err error) {
 	return t.execute(st, w, variables, data)
 }
 

--- a/exec.go
+++ b/exec.go
@@ -40,11 +40,21 @@ func (scope VarMap) SetWriter(name string, v SafeWriter) VarMap {
 	return scope
 }
 
+func (t *Template) ExecuteWith(r Resolver, w io.Writer, variables VarMap, data interface{}) (err error) {
+	st := pool_State.Get().(*Runtime)
+	st.WithResolver(r)
+	return t.execute(st, w, variables, data)
+}
+
 // Execute executes the template into w.
 func (t *Template) Execute(w io.Writer, variables VarMap, data interface{}) (err error) {
 	st := pool_State.Get().(*Runtime)
-	defer st.recover(&err)
+	return t.execute(st, w, variables, data)
+}
 
+// Execute executes the template into w.
+func (t *Template) execute(st *Runtime, w io.Writer, variables VarMap, data interface{}) (err error) {
+	defer st.recover(&err)
 	st.blocks = t.processedBlocks
 	st.variables = variables
 	st.set = t.set


### PR DESCRIPTION
Opening a PR with a _prototype_ as a means to discuss custom resolvers.  [Based off of this comment](https://github.com/CloudyKit/jet/issues/110#issuecomment-749494289) in #110, custom resolvers allow us to override default functionality when executing a template.  This would open the possibility to:

- Implement logging and tracing
- Implement custom error handling logic
- Implement introspection without navigating the AST

This PR is purely a concept.  It has no tests, and it exposes *Runtime directly from a template, which I do not like.  So, word of warning, this PR is _not ready_ and the aim here is to open a discussion with maintainers and owners regarding whether Resolver interfaces can be considered.

Stealing from my previous comment:


It adds a single interface - `Resovler`:
```go
type Resolver interface {
	Resolve(name string) (reflect.Value, error)
}
```

This allows us to define custom functions overriding default functionality in Resolve.  You can always get the default resolver functionality within Runtime by calling `runtime.DefaultResolver()`.

Usage:

```go
type CustomResolver struct {
  default jet.Resolver
}

func (cr *CustomResolver) Resolve(name string) (reflect.Value, error) {
        fmt.Printf("resolving %s\n", name)
        // Here, we can ignore the error from our default resolver, choose to do no resolving at all, etc.
        return cr.default(name)
}

var buf bytes.Buffer
tpl, err := jet.NewSet(jet.NewInMemLoader()).Parse("some-tpl.tpl". source)
runtime := tpl.Runtime()
runtime.WithResolver(&customResolver{})
tpl.ExecuteWith(runtime, buf, nil, nil)
```

I don't like how I have to expose the `Runtime()` func within templates to get the default resolver at all to be honest, but yeah, like I said - it's a hacky POC to show that interfaces here might help.