### PR TITLE
ranger: Improve intsRanger performance

### DIFF
--- a/default.go
+++ b/default.go
@@ -140,7 +140,7 @@ func init() {
 			return result
 		})),
 		"ints": reflect.ValueOf(Func(func(a Arguments) (result reflect.Value) {
-			var from, to int
+			var from, to int64
 			err := a.ParseInto(&from, &to)
 			if err != nil {
 				panic(err)
@@ -149,7 +149,7 @@ func init() {
 			if to <= from {
 				panic(errors.New("invalid range for ints ranger: 'from' must be smaller than 'to'"))
 			}
-			return reflect.ValueOf(&intsRanger{from: from, to: to})
+			return reflect.ValueOf(newIntsRanger(from, to))
 		})),
 		"dump": reflect.ValueOf(Func(func(a Arguments) (result reflect.Value) {
 			switch numArgs := a.NumOfArguments(); numArgs {

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -35,6 +35,7 @@
     - [Slices / Arrays](#slices--arrays)
     - [Maps](#maps)
     - [Channels](#channels)
+    - [Custom](#custom-ranger)
     - [else](#else)
   - [try](#try)
   - [try / catch](#try--catch)
@@ -366,7 +367,7 @@ Use `range` to iterate over data, just like you would in Go, or how you would us
         {{.}}
     {{ end }}
 
-Jet provides built-in rangers for Go slices, arrays, maps, and channels. You can add your own by implementing the Ranger interface. TODO
+Jet provides built-in rangers for Go slices, arrays, maps, and channels. You can add your own by implementing the Ranger interface.
 
 #### Slices / Arrays
 
@@ -410,6 +411,12 @@ When iterating over a channel, you can can have Jet assign the iteration value t
     {{ end }}
 
 It's an error to use channels together with the two-variable syntax.
+
+#### Custom Ranger
+
+Any value that implements the
+[Ranger](https://pkg.go.dev/github.com/CloudyKit/jet/v6#Ranger) interface can be
+used for ranging over values. Look in the package docs for an example.
 
 #### else
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -89,6 +89,7 @@ func init() {
 	JetTestingLoader.Set("rangeOverUsers_Set", `{{range index,user:= . }}{{index}}{{user.Name}}-{{user.Email}}{{end}}`)
 	JetTestingLoader.Set("BenchNewBlock", "{{ block col(md=12,offset=0) }}\n<div class=\"col-md-{{md}} col-md-offset-{{offset}}\">{{ yield content }}</div>\n\t\t{{ end }}\n\t\t{{ block row(md=12) }}\n<div class=\"row {{md}}\">{{ yield content }}</div>\n\t\t{{ content }}\n<div class=\"col-md-1\"></div>\n<div class=\"col-md-1\"></div>\n<div class=\"col-md-1\"></div>\n\t\t{{ end }}\n\t\t{{ block header() }}\n<div class=\"header\">\n\t{{ yield row() content}}\n\t\t{{ yield col(md=6) content }}\n{{ yield content }}\n\t\t{{end}}\n\t{{end}}\n</div>\n\t\t{{content}}\n<h1>Hey</h1>\n\t\t{{ end }}")
 	JetTestingLoader.Set("BenchCustomRanger", "{{range .}}{{.Name}}{{end}}")
+	JetTestingLoader.Set("BenchIntsRanger", "{{range ints(0, .)}} {{end}}")
 }
 
 func RunJetTest(t *testing.T, variables VarMap, context interface{}, testName, testContent, testExpected string) {
@@ -749,6 +750,7 @@ func TestRanger(t *testing.T) {
 	RunJetTest(t, data, nil, "map_ranger_key_value", `{{ range k, v := m }}{{k}}:{{v}},{{ end }}`, "asd:123,")
 	RunJetTest(t, data, nil, "chan_ranger", `{{ range v := c }}{{v}}{{ end }}`, "0123456789")
 	RunJetTest(t, nil, nil, "ints_ranger", `{{ range i := ints(0, 10) }}{{ (i == 0 ? "" : ", ") + i }}{{ end }}`, "0, 1, 2, 3, 4, 5, 6, 7, 8, 9")
+	RunJetTest(t, nil, nil, "ints_ranger_index_value", `{{ range k, v := ints(10, 20) }}{{k}}:{{v}} {{ end }}`, "0:10 1:11 2:12 3:13 4:14 5:15 6:16 7:17 8:18 9:19 ")
 	RunJetTest(t, data, nil, "custom_indexed_ranger", `{{ range ci }}{{.}},{{ end  }}`, "asd,foo,bar,")
 	RunJetTest(t, data, nil, "custom_indexed_ranger_key_context", `{{ range k := ci }}{{k}}:{{.}},{{ end  }}`, "0:asd,1:foo,2:bar,")
 	RunJetTest(t, data, nil, "custom_indexed_ranger_key_value", `{{ range k, v := ci }}{{k}}:{{v}},{{ end  }}`, "0:asd,1:foo,2:bar,")
@@ -923,6 +925,17 @@ func BenchmarkCustomRanger(b *testing.B) {
 	t, _ := JetTestingSet.GetTemplate("BenchCustomRanger")
 	b.ResetTimer()
 	err := t.Execute(ww, nil, execCtx)
+	if err != nil {
+		b.Error(err.Error())
+	}
+}
+
+// BenchmarkIntsRanger benchmarks the performance of doing one additional
+// iteration using the ints ranger.
+func BenchmarkIntsRanger(b *testing.B) {
+	t, _ := JetTestingSet.GetTemplate("BenchIntsRanger")
+	b.ResetTimer()
+	err := t.Execute(ww, nil, b.N)
 	if err != nil {
 		b.Error(err.Error())
 	}

--- a/ranger.go
+++ b/ranger.go
@@ -24,20 +24,35 @@ type Ranger interface {
 }
 
 type intsRanger struct {
-	i, from, to int
+	i, val, to int64
 }
 
 var _ Ranger = &intsRanger{}
 
 func (r *intsRanger) Range() (index, value reflect.Value, end bool) {
-	index = reflect.ValueOf(r.i)
-	value = reflect.ValueOf(r.from + r.i)
-	end = r.i == r.to-r.from
 	r.i++
+	r.val++
+	end = r.val == r.to
+
+	// The indirection in the ValueOf calls avoids an allocation versus
+	// using the concrete value of 'i' and 'val'. The downside is having
+	// to interpret 'r.i' as "the current value" after Range() returns,
+	// and so it needs to be initialized as -1.
+	index = reflect.ValueOf(&r.i).Elem()
+	value = reflect.ValueOf(&r.val).Elem()
 	return
 }
 
 func (r *intsRanger) ProvidesIndex() bool { return true }
+
+func newIntsRanger(from, to int64) *intsRanger {
+	r := &intsRanger{
+		to:  to,
+		i:   -1,
+		val: from - 1,
+	}
+	return r
+}
 
 type pooledRanger interface {
 	Ranger

--- a/ranger_test.go
+++ b/ranger_test.go
@@ -1,0 +1,52 @@
+package jet
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+)
+
+// exampleCustomBenchRanger satisfies the Ranger interface, generating fixed
+// data.
+type exampleCustomRanger struct {
+	i int
+}
+
+// Type assertion to verify exampleCustomRanger satisfies the Ranger interface.
+var _ Ranger = (*exampleCustomRanger)(nil)
+
+func (ecr *exampleCustomRanger) ProvidesIndex() bool {
+	// Return false if 'k' can't be filled in Range().
+	return true
+}
+
+func (ecr *exampleCustomRanger) Range() (k reflect.Value, v reflect.Value, done bool) {
+	if ecr.i >= 3 {
+		done = true
+		return
+	}
+
+	k = reflect.ValueOf(ecr.i)
+	v = reflect.ValueOf(fmt.Sprintf("custom ranger %d", ecr.i))
+	ecr.i += 1
+	return
+}
+
+// ExampleRanger demonstrates how to write a custom template ranger.
+func ExampleRanger() {
+	// Error handling ignored for brevity.
+	//
+	// Setup template and rendering.
+	loader := NewInMemLoader()
+	loader.Set("template", "{{range k := ecr }}{{k}}:{{.}}; {{end}}")
+	set := NewSet(loader, WithSafeWriter(nil))
+	t, _ := set.GetTemplate("template")
+
+	// Pass a custom ranger instance as the 'ecr' var.
+	vars := VarMap{"ecr": reflect.ValueOf(&exampleCustomRanger{})}
+
+	// Execute template.
+	_ = t.Execute(os.Stdout, vars, nil)
+
+	// Output: 0:custom ranger 0; 1:custom ranger 1; 2:custom ranger 2;
+}


### PR DESCRIPTION
This uses an indirection trick to avoid an allocation in intsRanger.Range call, signficantly improving its performance during iteration.

The trick involves calling reflect.ValueOf on the address of the field instead of using its concrete value. This avoids an allocation performed by the Go runtime to convert the int value to an interface value.

In order to use this trick, the interpretation of the 'i' field needed to be changed from "next index" to "previous index" and its initialization needed to be offset by -1.

Following is the impact of this change in the relevant benchmark:

```
name          old time/op    new time/op    delta
IntsRanger-4    61.0ns ± 2%    23.1ns ± 1%   -62.12%  (p=0.000 n=10+9)

name          old alloc/op   new alloc/op   delta
IntsRanger-4     15.0B ± 0%      0.0B       -100.00%  (p=0.000 n=9+10)

name          old allocs/op  new allocs/op  delta
IntsRanger-4      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

Additionally, it adds a benchmark to assert custom renderer performance.

It's now possible to execute templates with guaranteed zero memory allocations (during execution) by using a combination of int and custom rangers and either simple field access or custom renderers. 