### PR TITLE
fix ranger empty interface regression

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1706,6 +1706,10 @@ func buildCache(typ reflect.Type, cache map[string][]int, parent []int) {
 		index[len(parent)] = i
 
 		field := typ.Field(i)
+		if field.PkgPath != "" {
+			// field is unexported, skip
+			continue
+		}
 		if field.Anonymous {
 			typ := field.Type
 			if typ.Kind() == reflect.Struct {

--- a/eval.go
+++ b/eval.go
@@ -1634,8 +1634,10 @@ func resolveIndex(v, index reflect.Value, indexAsStr string) (reflect.Value, err
 			}
 			cachedStructsMutex.Unlock()
 		}
+
 		if id, ok := cache[key]; ok {
-			return v.FieldByIndex(id), nil
+			field := v.FieldByIndex(id)
+			return indirectEface(field), nil
 		}
 
 		// Slow path: use reflect directly

--- a/eval_test.go
+++ b/eval_test.go
@@ -549,6 +549,32 @@ func TestApple(t *testing.T) {
 	RunJetTest(t, data, nil, "LookUpApple", `{{apple := GetAppleByName("honeycrisp")}}{{TellFlavor(apple)}}`, "crisp")
 }
 
+func TestEvalStructFieldAccess(t *testing.T) {
+	s := struct {
+		Exported   int
+		unexported int
+	}{
+		Exported:   123,
+		unexported: 234,
+	}
+
+	var data = make(VarMap)
+	data.Set("struct", s)
+
+	RunJetTest(t, data, nil, "StructFieldAccess", `{{ struct.Exported }}`, "123")
+
+	var set = NewSet(NewInMemLoader(), WithSafeWriter(nil))
+	tt, err := set.parse("StructFieldAccess_unexported", `{{ struct.unexported }}`, false)
+	if err != nil {
+		t.Error(err)
+	}
+	buff := bytes.NewBuffer(nil)
+	err = tt.Execute(buff, data, nil)
+	if err == nil {
+		t.Error("expected evaluating unexported field of struct to fail with a runtime error but got nil")
+	}
+}
+
 func TestEvalStructFieldPointerExpressions(t *testing.T) {
 	var data = make(VarMap)
 

--- a/ranger_test.go
+++ b/ranger_test.go
@@ -38,15 +38,32 @@ func ExampleRanger() {
 	//
 	// Setup template and rendering.
 	loader := NewInMemLoader()
-	loader.Set("template", "{{range k := ecr }}{{k}}:{{.}}; {{end}}")
+	loader.Set("template",
+		`{{ range k := ecr }}
+{{k}} = {{.}}
+{{- end }}
+{{ range k := struct.RangerEface }}
+{{k}} = {{.}}
+{{- end }}`,
+	)
 	set := NewSet(loader, WithSafeWriter(nil))
 	t, _ := set.GetTemplate("template")
 
-	// Pass a custom ranger instance as the 'ecr' var.
-	vars := VarMap{"ecr": reflect.ValueOf(&exampleCustomRanger{})}
+	// Pass a custom ranger instance as the 'ecr' var, as well as in a struct field with type interface{}.
+	vars := VarMap{
+		"ecr":    reflect.ValueOf(&exampleCustomRanger{}),
+		"struct": reflect.ValueOf(struct{ RangerEface interface{} }{RangerEface: &exampleCustomRanger{}}),
+	}
 
 	// Execute template.
 	_ = t.Execute(os.Stdout, vars, nil)
 
-	// Output: 0:custom ranger 0; 1:custom ranger 1; 2:custom ranger 2;
+	// Output:
+	// 0 = custom ranger 0
+	// 1 = custom ranger 1
+	// 2 = custom ranger 2
+	//
+	// 0 = custom ranger 0
+	// 1 = custom ranger 1
+	// 2 = custom ranger 2
 }


### PR DESCRIPTION
The regression was introduced in 3838f8b1234c7dd32a42bf3ec55d79f426deb03e as part of the struct field caching.

As a bonus, I found and fixed another bug in that same commit that allowed accessing unexported struct fields from templates.

Fixes #220.