### PR TITLE
Update link for Go API to point to pkg.go.dev instead of beta.pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Version 6 brings major improvements to the Go API. Make sure to read through the
 
 ## Docs
 
-- [Go API](https://beta.pkg.go.dev/github.com/CloudyKit/jet/v6#section-documentation)
+- [Go API](https://pkg.go.dev/github.com/CloudyKit/jet/v6#section-documentation)
 - [Syntax Reference](./docs/syntax.md)
 - [Built-ins](./docs/builtins.md)
 - [Wiki](https://github.com/CloudyKit/jet/wiki) (some things are out of date)


### PR DESCRIPTION
beta.pkg.go.dev requires a login