### PR TITLE
chore: fix typo "occured" → "occurred" in eval.go comment

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -575,7 +575,7 @@ func (st *Runtime) executeTry(try *TryNode) (returnValue reflect.Value) {
 	defer func() {
 		r := recover()
 
-		// copy buffered render output to writer only if no panic occured
+		// copy buffered render output to writer only if no panic occurred
 		if r == nil {
 			io.Copy(writer, buf)
 		} else {


### PR DESCRIPTION
Comment-only fix in `eval.go`: corrects the typo "occured" → "occurred" in an inline code comment. No behavior change.
