### PR TITLE
fix(eval): return error for out-of-range slice expression instead of panicking

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -719,6 +719,11 @@ func (st *Runtime) evalPrimaryExpressionGroup(node Expression) reflect.Value {
 			length = baseExpression.Len()
 		}
 
+		// validate bounds so an out-of-range slice yields a template error instead of a runtime panic
+		if index < 0 || length < index || length > baseExpression.Len() {
+			node.errorf("slice bounds out of range [%d:%d] with length %d", index, length, baseExpression.Len())
+		}
+
 		return baseExpression.Slice(index, length)
 	}
 	return st.evalBaseExpressionGroup(node)

--- a/eval_test.go
+++ b/eval_test.go
@@ -446,6 +446,36 @@ func TestEvalSliceExpression(t *testing.T) {
 	RunJetTest(t, nil, []string{"111"}, "SliceExpressionSlice_IfLen", `{{if len(.) > 0}}{{.[0]}}{{end}}`, `111`)
 }
 
+func TestEvalSliceExpressionOutOfRange(t *testing.T) {
+	cases := []string{
+		`{{ .[1:10] }}`,
+		`{{ .[5:6] }}`,
+		`{{ .[-1:1] }}`,
+		`{{ .[2:1] }}`,
+	}
+	for i, content := range cases {
+		name := fmt.Sprintf("SliceOutOfRange_%d", i)
+		loader := NewInMemLoader()
+		loader.Set(name, content)
+		set := NewSet(loader)
+		tpl, err := set.GetTemplate(name)
+		if err != nil {
+			t.Fatalf("%s: parse error: %v", name, err)
+		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("%s: panicked instead of returning error: %v", name, r)
+				}
+			}()
+			var buf bytes.Buffer
+			if err := tpl.Execute(&buf, nil, []string{"a", "b"}); err == nil {
+				t.Errorf("%s: expected error for out-of-range slice, got %q", name, buf.String())
+			}
+		}()
+	}
+}
+
 type StringerType struct {
 	//
 }


### PR DESCRIPTION
Slice expressions like `{{ .[1:10] }}` on a shorter slice pass the user-controlled bounds straight into `reflect.Value.Slice`, which panics with a `runtime.Error` ("slice index out of bounds"). The runtime recover in `(*Runtime).recover` re-panics on `runtime.Error`, so this crashes the calling application instead of being returned as a normal template error.

The index path (`indexArg`) already validates bounds and returns an error; this brings slice expressions in line by validating `index`/`length` against the base length before calling `Slice`.

Reproduces with `{{ .[1:10] }}`, `{{ .[2:1] }}`, and `{{ .[-1:1] }}`.

Added `TestEvalSliceExpressionOutOfRange` covering over-length, reversed, and negative bounds. It panics without the fix and passes with it. Full suite green under `go test -race ./...`.